### PR TITLE
Improve activities

### DIFF
--- a/img/shield-green.svg
+++ b/img/shield-green.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4"
+   x="0px"
+   y="0px"
+   version="1.1"
+   width="32"
+   viewBox="0 0 31.999999 32"
+   height="32"
+   xml:space="preserve"
+   enable-background="new 0 0 100 100"><metadata
+     id="metadata10"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs8" /><path
+     style="fill:#00ff00;fill-opacity:1"
+     id="path2"
+     d="m2.3136 4.8882c-0.20153 1.3083-0.31365 2.6417-0.31365 4.0019 0 10.022 5.6475 18.72 13.923 23.11 8.2762-4.3901 13.923-13.088 13.923-23.11 0-1.3602-0.11443-2.6936-0.31226-4.0019 0 0-9.5447-1.2597-13.636-4.8882-3.784 3.7424-13.584 4.8881-13.584 4.8881z"
+     fill="#fff" /></svg>

--- a/img/shield-red.svg
+++ b/img/shield-red.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4"
+   x="0px"
+   y="0px"
+   version="1.1"
+   width="32"
+   viewBox="0 0 31.999999 32"
+   height="32"
+   xml:space="preserve"
+   enable-background="new 0 0 100 100"><metadata
+     id="metadata10"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs8" /><path
+     style="fill:#ff0000;fill-opacity:1"
+     id="path2"
+     d="m2.3136 4.8882c-0.20153 1.3083-0.31365 2.6417-0.31365 4.0019 0 10.022 5.6475 18.72 13.923 23.11 8.2762-4.3901 13.923-13.088 13.923-23.11 0-1.3602-0.11443-2.6936-0.31226-4.0019 0 0-9.5447-1.2597-13.636-4.8882-3.784 3.7424-13.584 4.8881-13.584 4.8881z"
+     fill="#fff" /></svg>

--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -96,7 +96,7 @@ class AvirWrapper extends Wrapper{
 
 							$activity = $this->activityManager->generateEvent();
 							$activity->setApp(Application::APP_NAME)
-								->setSubject(Provider::SUBJECT_VIRUS_DETECTED, [$path, $status->getDetails()])
+								->setSubject(Provider::SUBJECT_VIRUS_DETECTED_UPLOAD, [$status->getDetails()])
 								->setMessage(Provider::MESSAGE_FILE_DELETED)
 								->setObject('', 0, $path)
 								->setAffectedUser($owner)

--- a/lib/ItemFactory.php
+++ b/lib/ItemFactory.php
@@ -26,6 +26,7 @@ namespace OCA\Files_Antivirus;
 use OCA\Files_Antivirus\Db\ItemMapper;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\Files\File;
+use OCP\Files\IRootFolder;
 use OCP\ILogger;
 
 class ItemFactory {
@@ -41,6 +42,9 @@ class ItemFactory {
 	/** @var ILogger */
 	private $logger;
 
+	/** @var IRootFolder */
+	private $rootFolder;
+
 	/**
 	 * ItemFactory constructor.
 	 *
@@ -48,15 +52,18 @@ class ItemFactory {
 	 * @param ActivityManager $activityManager
 	 * @param ItemMapper $itemMapper
 	 * @param ILogger $logger
+	 * @param IRootFolder $rootFolder
 	 */
 	public function __construct(AppConfig $appConfig,
 								ActivityManager $activityManager,
 								ItemMapper $itemMapper,
-								ILogger $logger) {
+								ILogger $logger,
+								IRootFolder $rootFolder) {
 		$this->config = $appConfig;
 		$this->activityManager = $activityManager;
 		$this->itemMapper = $itemMapper;
 		$this->logger = $logger;
+		$this->rootFolder = $rootFolder;
 	}
 
 	/**
@@ -69,6 +76,7 @@ class ItemFactory {
 			$this->activityManager,
 			$this->itemMapper,
 			$this->logger,
+			$this->rootFolder,
 			$file
 		);
 	}


### PR DESCRIPTION
Now it kinda looks like:

![new_activity](https://user-images.githubusercontent.com/45821/37033035-c5dad080-2144-11e8-8769-17fabe8d1089.png)


So from bottom to top.

1. Uploading a file containing a virus with the virus scanner enabled
  - This results in a green shield
  - File is deleted/not uploaded
2. Uploading a file with a virus with the virus scanner disabled
  - Normal upload
3. Background scan with only logging
  - Red shield (since the file remains and action might be needed)
  - Rich link (you can click it!)
4. Background scan with deletion as well
  - Green shield (no more bad file)
 
Obviously the badges look crappy now. But I needed something to distinguish the cases.

@nextcloud/designers  @MorrisJobke 
@nickvergessen for general activity stuff :)
