### PR TITLE
Change green shield for dark shield

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -93,7 +93,7 @@ class Provider implements IProvider {
 			if ($event->getMessage() === self::MESSAGE_FILE_DELETED) {
 				$event->setParsedMessage($l->t('The file has been removed'));
 			}
-			$event->setIcon($this->urlGenerator->imagePath('files_antivirus', 'shield-green.svg'));
+			$event->setIcon($this->urlGenerator->imagePath('files_antivirus', 'shield-dark.svg'));
 		} else if ($event->getSubject() === self::SUBJECT_VIRUS_DETECTED_SCAN) {
 			$subject = $l->t('File {file} is infected with {virus}');
 
@@ -108,7 +108,7 @@ class Provider implements IProvider {
 				$event->setParsedMessage($l->t('The file has been removed'));
 
 				$parameters['file'] = $this->getFileDeleted($event);
-				$event->setIcon($this->urlGenerator->imagePath('files_antivirus', 'shield-green.svg'));
+				$event->setIcon($this->urlGenerator->imagePath('files_antivirus', 'shield-dark.svg'));
 			} else {
 				$parameters['file'] = $this->getFileExisting($event);
 				$event->setIcon($this->urlGenerator->imagePath('files_antivirus', 'shield-red.svg'));


### PR DESCRIPTION
It was confusing and had too much color. It’s also unclear what the cases are. To make it simpler:
- A normal case is a »dark«/neutral shield, if an upload is prevented for example
- A case where you need to act is red

Please check @rullzer @MorrisJobke 