### PR TITLE
Correction of Logs entry

### DIFF
--- a/lib/Item.php
+++ b/lib/Item.php
@@ -212,9 +212,9 @@ class Item {
 		$owner = $this->file->getOwner();
 
 		if ($owner === null) {
-			$ownerInfo = 'Account: NO OWNER FOUND';
+			$ownerInfo = ' Account: NO OWNER FOUND';
 		} else {
-			$ownerInfo = 'Account: ' . $owner->getUID();
+			$ownerInfo = ' Account: ' . $owner->getUID();
 		}
 
 		$extra = ' File: ' . $this->file->getId()


### PR DESCRIPTION
Currently there is no space between file ID and Account:
```
Infected file found (during background scan) Win.Test.EICAR_HDB-1 File: 4622181Account: USER Path....
```
With this fix will be:
```
Infected file found (during background scan) Win.Test.EICAR_HDB-1 File: 4622181 Account: USER Path....
```