### PR TITLE
verify that a file is a accessible before scanning it

### DIFF
--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -111,7 +111,9 @@ class BackgroundScanner extends TimedJob {
 
 					$file = array_pop($files);
 					if ($file instanceof File) {
-						$this->scanOneFile($file);
+						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
+							$this->scanOneFile($file);
+						}
 					} else {
 						$this->logger->error('Tried to scan non file');
 					}
@@ -146,7 +148,7 @@ class BackgroundScanner extends TimedJob {
 				foreach ($users as $user) {
 					/** @var IUser $owner */
 					$owner = $this->userManager->get($user['user_id']);
-					if (!$owner instanceof IUser){
+					if (!$owner instanceof IUser) {
 						continue;
 					}
 
@@ -158,8 +160,11 @@ class BackgroundScanner extends TimedJob {
 					}
 
 					$file = array_pop($files);
+
 					if ($file instanceof File) {
-						$this->scanOneFile($file);
+						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
+							$this->scanOneFile($file);
+						}
 					} else {
 						$this->logger->error('Tried to scan non file');
 					}
@@ -203,7 +208,9 @@ class BackgroundScanner extends TimedJob {
 
 					$file = array_pop($files);
 					if ($file instanceof File) {
-						$this->scanOneFile($file);
+						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
+							$this->scanOneFile($file);
+						}
 					} else {
 						$this->logger->error('Tried to scan non file');
 					}


### PR DESCRIPTION
in case a storage is shadowing an existing folder, getById can return items that aren't accessible

a different, long term, solution would be to change the `File` implementation to allow it to access the shadowed files but that would require much bigger changes.