### PR TITLE
Reset infectedStatus when scanning new item

### DIFF
--- a/lib/Scanner/ScannerBase.php
+++ b/lib/Scanner/ScannerBase.php
@@ -106,6 +106,7 @@ abstract class ScannerBase implements IScanner {
 	 * @return Status
 	 */
 	public function scan(Item $item): Status {
+		$this->infectedStatus = null;
 		$this->initScanner();
 
 		while (false !== ($chunk = $item->fread())) {
@@ -117,6 +118,7 @@ abstract class ScannerBase implements IScanner {
 	}
 
 	public function scanString(string $data): Status {
+		$this->infectedStatus = null;
 		$this->initScanner();
 
 		$this->writeChunk($data);


### PR DESCRIPTION
Fix #167 by resetting the `infectedStatus` property of the scanner when starting to scan a new file.

I went ahead and implemented solution two, since it is actually much easier than I thought.
Just reset the `infectedStatus` when using the `scan` method since it is used by and only by the background scanner, and once per file (versus multiple times per file for the `initScanner` function).