### PR TITLE
Update check-time of scanned files, even when infected

### DIFF
--- a/lib/Item.php
+++ b/lib/Item.php
@@ -128,6 +128,7 @@ class Item {
 				$msg = 'Infected file found.';
 			}
 			$this->logError($msg . ' ' . $status->getDetails());
+			$this->updateCheckTime();
 		}
 	}
 
@@ -144,6 +145,13 @@ class Item {
 	 * Action to take if this item status is not infected
 	 */
 	public function processClean() {
+		$this->updateCheckTime();
+	}
+
+	/**
+	 * Update the check-time of this item to current time
+	 */
+	private function updateCheckTime() {
 		try {
 			try {
 				$item = $this->itemMapper->findByFileId($this->file->getId());


### PR DESCRIPTION
I've not opened an issue for this, but when files are scanned and detected as infected, their check-time is not updated, meaning that the next background scan we scan it again. This result in unnecessary resource usage, and an activity and log spam.

This PR update the check-time both on clean files and infected files.