### PR TITLE
handle extra content after clean for kaspersky

### DIFF
--- a/lib/Scanner/ExternalKaspersky.php
+++ b/lib/Scanner/ExternalKaspersky.php
@@ -79,7 +79,9 @@ class ExternalKaspersky extends ScannerBase {
 			['app' => 'files_antivirus']
 		);
 
-		if (trim($response) === 'CLEAN' && $this->status->getNumericStatus() != Status::SCANRESULT_INFECTED) {
+		$response = trim($response);
+
+		if (substr($response, 0, 5) === 'CLEAN' && $this->status->getNumericStatus() != Status::SCANRESULT_INFECTED) {
 			$this->status->setNumericStatus(Status::SCANRESULT_CLEAN);
 		} else if (substr($response, 0, 11) === 'NON_SCANNED' && $this->status->getNumericStatus() != Status::SCANRESULT_INFECTED) {
 			$this->status->setNumericStatus(Status::SCANRESULT_UNCHECKED);


### PR DESCRIPTION
kaspersky can put more stuff after the CLEAN result

Signed-off-by: Robin Appelman <robin@icewind.nl>