### PR TITLE
Only scan user files #1

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -98,7 +98,7 @@ class AvirWrapper extends Wrapper {
 		return $this->shouldScan
 			&& (!$this->isHomeStorage
 				|| (strpos($path, 'files/') === 0
-					|| strpos($path, '/files/') == 0)
+					|| strpos($path, '/files/') === 0)
 			);
 	}
 

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -104,4 +104,22 @@ class AvirWrapperTest extends TestBase {
 		fwrite($fd, str_repeat('0', DummyClam::TEST_STREAM_SIZE - 2) . DummyClam::TEST_SIGNATURE);
 		fwrite($fd, DummyClam::TEST_SIGNATURE);
 	}
+
+	/**
+	 * @dataProvider shouldWrapProvider
+	 */
+	public function testShouldWrap(string $path, bool $expected) {
+		$actual = self::invokePrivate($this->wrappedStorage, 'shouldWrap', [$path]);
+		self::assertEquals($expected, $actual);
+	}
+
+	public function shouldWrapProvider(): array {
+		return [
+			['/files/my_file_1', true],
+			['files/my_file_2', true],
+			['/files_external/rootcerts.crt', false],
+			['/files_external/rootcerts.crt.tmp.0123456789', false],
+			['/root_file', false],
+		];
+	}
 }


### PR DESCRIPTION
### Second iteration (fix check if a file is inside the users home storage) 

https://github.com/nextcloud/files_antivirus/blob/e9955478525509569c1a8810024a70af1193ff4b/lib/AvirWrapper.php#L77-L83

https://github.com/nextcloud/files_antivirus/blob/e888f598f93f9864c509f19e6f1a32d79186b033/lib/AvirWrapper.php#L97-L103

When `AvirWrapper.shouldWrap` returns true the storage wrapper for scanning a file is attached => the file will be scanned.

I assume the method should return true when a file is in the users home directory or moved into it. A chunk has a path like `uploads/web-file-upload-a37afee81a3d38104ab8808b454e5590-1629448320149/0.ocTransferId741408323.part`. `AvirWrapper.shouldWrap` return true for this path because `strpos($path, '/files/')` returns false and is loosely compared to 0 => evaluating to true. 


### First iteration (exclude certificate bundle from scanner)

Currently, the certificate bundles are scanned which can lead to an endless recursion when Kaspersky is used. I solved this by ignoring certificate bundles entirely. 

1. A new certificate is requested (e.g. by the app updater).
2. New bundle is written and scanned.
3. Upon finishing the scan, a post request is send to Kaspersky. 
2. The instantiated client for the request will try to load a certificate bundle (because the previous one is not yet finished due to it being stuck on scanning).
3. A new bundle is created and then scanned.
4. The client tries to create another bundle.
5. To be continued ...

Feedback is highly appreciated as I'm not familiar with the code. Feel free to suggest a better solution.

Excerpt of the recursion on a live system:
```
#198 /var/www/html/nextcloud/apps/files_antivirus/lib/AvirWrapper.php(118): OCA\Files_Antivirus\Scanner\ScannerBase->completeAsyncScan()
#199 [internal function]: OCA\Files_Antivirus\AvirWrapper->OCA\Files_Antivirus\{closure}()
#200 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/CallbackWrapper.php(121): call_user_func()
#201 [internal function]: Icewind\Streams\CallbackWrapper->stream_close()
#202 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php(132): fclose()
#203 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/CallbackWrapper.php(119): Icewind\Streams\Wrapper->stream_close()
#204 [internal function]: Icewind\Streams\CallbackWrapper->stream_close()
#205 /var/www/html/nextcloud/lib/private/Security/CertificateManager.php(157): fclose()
#206 /var/www/html/nextcloud/lib/private/Security/CertificateManager.php(235): OC\Security\CertificateManager->createCertificateBundle()
#207 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(104): OC\Security\CertificateManager->getAbsoluteBundlePath()
#208 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(75): OC\Http\Client\Client->getCertBundle()
#209 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(299): OC\Http\Client\Client->buildRequestOptions()
#210 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ExternalKaspersky.php(74): OC\Http\Client\Client->post()
#211 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ExternalKaspersky.php(97): OCA\Files_Antivirus\Scanner\ExternalKaspersky->scanBuffer()
#212 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ScannerBase.php(145): OCA\Files_Antivirus\Scanner\ExternalKaspersky->shutdownScanner()
#213 /var/www/html/nextcloud/apps/files_antivirus/lib/AvirWrapper.php(118): OCA\Files_Antivirus\Scanner\ScannerBase->completeAsyncScan()
#214 [internal function]: OCA\Files_Antivirus\AvirWrapper->OCA\Files_Antivirus\{closure}()
#215 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/CallbackWrapper.php(121): call_user_func()
#216 [internal function]: Icewind\Streams\CallbackWrapper->stream_close()
#217 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/Wrapper.php(132): fclose()
#218 /var/www/html/nextcloud/apps/files_external/3rdparty/icewind/streams/src/CallbackWrapper.php(119): Icewind\Streams\Wrapper->stream_close()
#219 [internal function]: Icewind\Streams\CallbackWrapper->stream_close()
#220 /var/www/html/nextcloud/lib/private/Security/CertificateManager.php(157): fclose()
#221 /var/www/html/nextcloud/lib/private/Security/CertificateManager.php(235): OC\Security\CertificateManager->createCertificateBundle()
#222 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(104): OC\Security\CertificateManager->getAbsoluteBundlePath()
#223 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(75): OC\Http\Client\Client->getCertBundle()
#224 /var/www/html/nextcloud/lib/private/Http/Client/Client.php(299): OC\Http\Client\Client->buildRequestOptions()
#225 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ExternalKaspersky.php(74): OC\Http\Client\Client->post()
#226 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ExternalKaspersky.php(97): OCA\Files_Antivirus\Scanner\ExternalKaspersky->scanBuffer()
#227 /var/www/html/nextcloud/apps/files_antivirus/lib/Scanner/ScannerBase.php(145): OCA\Files_Antivirus\Scanner\ExternalKaspersky->shutdownScanner()
#228 /var/www/html/nextcloud/apps/files_antivirus/lib/AvirWrapper.php(118): OCA\Files_Antivirus\Scanner\ScannerBase->completeAsyncScan()
``` 