### PR TITLE
ScannerFactory.getScanner should always return a fresh scanner instance.

### DIFF
--- a/lib/Scanner/ScannerBase.php
+++ b/lib/Scanner/ScannerBase.php
@@ -106,7 +106,6 @@ abstract class ScannerBase implements IScanner {
 	 * @return Status
 	 */
 	public function scan(Item $item): Status {
-		$this->infectedStatus = null;
 		$this->initScanner();
 
 		while (false !== ($chunk = $item->fread())) {
@@ -118,7 +117,6 @@ abstract class ScannerBase implements IScanner {
 	}
 
 	public function scanString(string $data): Status {
-		$this->infectedStatus = null;
 		$this->initScanner();
 
 		$this->writeChunk($data);

--- a/lib/Scanner/ScannerFactory.php
+++ b/lib/Scanner/ScannerFactory.php
@@ -42,6 +42,6 @@ class ScannerFactory {
 				throw new \InvalidArgumentException('Application is misconfigured. Please check the settings at the admin page. Invalid mode: ' . $avMode);
 		}
 
-		return $this->serverContainer->query($scannerClass);
+		return $this->serverContainer->resolve($scannerClass);
 	}
 }


### PR DESCRIPTION
Fix #202 

Summary: A file scanned after an infected files is also infected.

How to reproduce:

- Disable files_antivirus
- Upload EICAR test file
- Upload another (not infected) file
- Enable files_antivirus
- Set a breakpoint https://github.com/nextcloud/files_antivirus/blob/43bd5323a47df3ffbcfad2272a5c7202a400db33/lib/BackgroundJob/BackgroundScanner.php#L335
- Trigger background job (Note: To run the steps again you may truncate oc_files_antivirus to reset the list of already scanned files. If they background job is not triggered again check last_run, last_checked, reserved_at in oc_jobs)

https://github.com/nextcloud/files_antivirus/blob/f3a55a98772e24e11384f52a1bd7f11e0bafe72a/lib/Scanner/ScannerBase.php#L150-L156

`IScanner.initScanner` is called by `ScannerBase.scan`,  `ScannerBase.scanString`, `ScannerBase.retry`. If files_antivirus is connected to a scanner via socket it may happen that writing to the socket is not possible anymore. We have to reopen the socket to write more data. That seems the reason for the above copy the status when infected logic in `ScannerBase.initScanner`: Keep the current status when reopening the socket. 

This pull request change `ScannerFactory.getScanner` to always return a fresh instance of a scanner object. An alternative approach might be to introduce a resetScanner method (to be called by `ScannerBase.scan` and `Scanner.scanString`) and reset `$status, $infectedStatus, $writeHandle, $lastChunk, $isLogUsed, $isAborted`. 

I guess both ways should work fine. Yet with the current approach (fresh instance for each file) we have more instances of the scanner around when running the background scan. 
