### PR TITLE
Only scan user files #2

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -8,14 +8,13 @@
 
 namespace OCA\Files_Antivirus;
 
-use \OCP\IConfig;
+use OCP\IConfig;
 
 /**
  * @method string getAvMode()
  * @method string getAvSocket()
  * @method string getAvHost()
  * @method int getAvPort()
- * @method int getAvMaxFileSize()
  * @method string getAvCmdOptions()
  * @method string getAvPath()
  * @method string getAvInfectedAction()
@@ -65,13 +64,17 @@ class AppConfig {
 		return 8192;
 	}
 
+	public function getAvMaxFileSize(): int {
+		return (int)$this->getAppValue('av_max_file_size');
+	}
+
 	/**
 	 * Get full commandline
 	 * @return string
 	 */
 	public function getCmdline() {
 		$avCmdOptions = $this->getAvCmdOptions();
-		
+
 		$shellArgs = [];
 		if ($avCmdOptions) {
 			$shellArgs = explode(',', $avCmdOptions);
@@ -81,14 +84,14 @@ class AppConfig {
 				$shellArgs
 			);
 		}
-		
+
 		$preparedArgs = '';
 		if (count($shellArgs)) {
 			$preparedArgs = implode(' ', $shellArgs);
 		}
 		return $preparedArgs;
 	}
-	
+
 	/**
 	 * Get all setting values as an array
 	 * @return array
@@ -99,7 +102,7 @@ class AppConfig {
 		$preparedKeys = array_map([$this, 'camelCase'], $keys);
 		return array_combine($preparedKeys, $values);
 	}
-	
+
 	/**
 	 * Get a value by key
 	 * @param string $key
@@ -121,7 +124,7 @@ class AppConfig {
 	public function setAppValue($key, $value) {
 		$this->config->setAppValue($this->appName, $key, $value);
 	}
-	
+
 	/**
 	 * Set a value with magic __call invocation
 	 * @param string $key
@@ -149,7 +152,7 @@ class AppConfig {
 
 		throw new \BadFunctionCallException($key . ' is not a valid key');
 	}
-	
+
 	/**
 	 * Translates property_name into propertyName
 	 * @param string $property
@@ -160,7 +163,7 @@ class AppConfig {
 		$ucFirst = implode('', array_map('ucfirst', $split));
 		return lcfirst($ucFirst);
 	}
-	
+
 	/**
 	 * Does all the someConfig to some_config magic
 	 * @param string $property
@@ -180,7 +183,7 @@ class AppConfig {
 
 		return $column;
 	}
-	
+
 	/**
 	 * Get/set an option value by calling getSomeOption method
 	 * @param string $methodName

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -244,7 +244,7 @@ class BackgroundScanner extends TimedJob {
 	}
 
 	protected function getSizeLimitExpression(IQueryBuilder $qb) {
-		$sizeLimit = (int)$this->appConfig->getAvMaxFileSize();
+		$sizeLimit = $this->appConfig->getAvMaxFileSize();
 		if ($sizeLimit === -1) {
 			$sizeLimitExpr = $qb->expr()->neq('fc.size', $qb->expr()->literal('0'));
 		} else {

--- a/lib/Sabre/PropfindPlugin.php
+++ b/lib/Sabre/PropfindPlugin.php
@@ -63,7 +63,8 @@ class PropfindPlugin extends ServerPlugin {
 			return;
 		}
 
-		if ($sourceNode->getSize() > $this->appConfig->getAvMaxFileSize()) {
+		$avMaxFileSize = $this->appConfig->getAvMaxFileSize();
+		if ($avMaxFileSize > -1 && $sourceNode->getSize() > $avMaxFileSize) {
 			$this->eventDispatcher->dispatch(
 				ScanStateEvent::class,
 				new ScanStateEvent(false)

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -55,10 +55,10 @@ script('files_antivirus', 'settings');
 					<td></td>
 				</tr>
 				<tr class="av_max_file_size">
-					<td><label for="av_max_file_size"><?php p($l->t('File size limit for periodic background scans, -1 means no limit'));?></label></td>
+					<td><label for="av_max_file_size"><?php p($l->t('File size limit for periodic background scans and chunked uploads, -1 means no limit'));?></label></td>
 					<td>
 						<input type="text" id="av_max_file_size" name="avMaxFileSize" value="<?php p($_['avMaxFileSize']); ?>"
-						   title="<?php p($l->t('Background scan file size limit in bytes, -1 means no limit'));?>"
+						   title="<?php p($l->t('Background scan and chunked upload file size limit in bytes, -1 means no limit'));?>"
 						/>
 					</td>
 					<td><label for="av_max_file_size" class="a-left"><?php p($l->t('bytes'))?></label></td>


### PR DESCRIPTION
- [x] Rebase when https://github.com/nextcloud/files_antivirus/pull/201 is merged and drop commit https://github.com/nextcloud/files_antivirus/pull/205/commits/e9955478525509569c1a8810024a70af1193ff4b.

Summary: Uploading a file via web client is slow when files_antivirus is enabled

When investigation the above question I run into some weird states. My knowledge about this app is low. Review carefully. 

A file uploaded in chunks is assembled on the server again by a move operation (done by the clients).
 
https://github.com/nextcloud/files_antivirus/blob/e888f598f93f9864c509f19e6f1a32d79186b033/lib/Sabre/PropfindPlugin.php#L66-L71

Is a plugin for the move operation. It's possible to configure a file size limit av_max_file_size for the background scanner. For some reason this value is also taken into account when moving the assembled file to the final destination. If the size of the assembled file is bigger than av_max_file_size dont' scan. Unfortunately the default is -1 and the above condition will evaluate to true and disable the scan. 

Example: Alice uploads a file with 50 MB (6348800 bytes)

| | Before | After |
| --- | --- | --- |
| av_max_file_size -1 | [x] chunks scanned<br /> [] assembled file scanned  | [ ] chunks scanned<br />[x] assembled file scanned  |
| av_max_file_size 104857600 | [x] chunks scanned<br /> [x] assembled file scanned  | [ ] chunks scanned<br />[x] assembled file scanned  |
