### PR TITLE
Optimize slow DB query

### DIFF
--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -314,10 +314,10 @@ class BackgroundScanner extends TimedJob {
 			->from('files_antivirus')
 			->andWhere($qb2->expr()->lt('check_time', $qb2->createNamedParameter($yesterday)))
 			->orderBy('check_time', 'ASC');
-
-		$qb2->select('fileid', 'storage')
-			->from('filecache', 'fc')
-			->where($qb2->expr()->in('fileid', $qb2->createFunction($qb1->getSQL())))
+		$qb2->select('fc.fileid', 'fc.storage')
+                        ->from('filecache', 'fc')
+                        ->leftJoin('fc', 'files_antivirus', 'fa', $qb2->expr()->eq('fc.fileid', 'fa.fileid'))
+                        ->where($qb2->expr()->isNull('fa.fileid'))
 			->andWhere($qb2->expr()->neq('mimetype', $qb2->expr()->literal($dirMimeTypeId)))
 			->andWhere($qb2->expr()->like('path', $qb2->expr()->literal('files/%')))
 			->andWhere($this->getSizeLimitExpression($qb2))

--- a/tests/BackgroundScannerTest.php
+++ b/tests/BackgroundScannerTest.php
@@ -49,12 +49,12 @@ class BackgroundScannerTest extends TestBase {
 		/** @var IDBConnection $db */
 		$db = \OC::$server->get(IDBConnection::class);
 
-		$db->getQueryBuilder()->delete('files_antivirus')->executeStatement();
+		$db->getQueryBuilder()->delete('files_antivirus')->execute();
 
 		$query = $db->getQueryBuilder();
 		$query->select('fileid')
 			->from('filecache');
-		$fileIds = $query->executeQuery()->fetchAll(\PDO::FETCH_COLUMN);
+		$fileIds = $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
 
 		$query = $db->getQueryBuilder();
 		$query->insert('files_antivirus')
@@ -64,7 +64,7 @@ class BackgroundScannerTest extends TestBase {
 			]);
 		foreach ($fileIds as $fileId) {
 			$query->setParameter('fileid', $fileId);
-			$query->executeStatement();
+			$query->execute();
 		}
 	}
 
@@ -76,7 +76,7 @@ class BackgroundScannerTest extends TestBase {
 		$query->update('files_antivirus')
 			->set('check_time', $query->createNamedParameter($time))
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId)));
-		$query->executeStatement();
+		$query->execute();
 	}
 
 	public function testGetUnscannedFiles() {

--- a/tests/BackgroundScannerTest.php
+++ b/tests/BackgroundScannerTest.php
@@ -12,7 +12,6 @@ namespace OCA\Files_Antivirus\Tests;
 
 use OC\Files\Storage\Temporary;
 use OCA\Files_Antivirus\BackgroundJob\BackgroundScanner;
-use Doctrine\DBAL\Driver\PDOStatement;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;


### PR DESCRIPTION
As per https://github.com/nextcloud/files_antivirus/issues/177#issuecomment-742831423 the query using NOT IN has been replaced with a LEFT JOIN

Looks functional after having it run on a 200+ user server for a while, it got rid of the horrendous 20 hour hang caused by running the query on PostgreSQL databases and it shouldn't be any slower on MariaDB/MySQL.

I'm not really a PHP dev so excuse me if there's anything really wrong with this change :)