### PR TITLE
handle password protected files as 'scanned' in kaspersky

### DIFF
--- a/lib/Scanner/ExternalKaspersky.php
+++ b/lib/Scanner/ExternalKaspersky.php
@@ -85,7 +85,12 @@ class ExternalKaspersky extends ScannerBase {
 		if (substr($response, 0, 5) === 'CLEAN' && $this->status->getNumericStatus() != Status::SCANRESULT_INFECTED) {
 			$this->status->setNumericStatus(Status::SCANRESULT_CLEAN);
 		} elseif (substr($response, 0, 11) === 'NON_SCANNED' && $this->status->getNumericStatus() != Status::SCANRESULT_INFECTED) {
-			$this->status->setNumericStatus(Status::SCANRESULT_UNCHECKED);
+			if ($response === 'NON_SCANNED (PASSWORD PROTECTED)') {
+				// if we can't scan the file at all, there is no use in trying to scan it again later
+				$this->status->setNumericStatus(Status::SCANRESULT_CLEAN);
+			} else {
+				$this->status->setNumericStatus(Status::SCANRESULT_UNCHECKED);
+			}
 			$this->status->setDetails($response);
 		} else {
 			$this->status->setNumericStatus(Status::SCANRESULT_INFECTED);


### PR DESCRIPTION
since there is nothing kaspersky can do with the files there is no use in retrying the scan later, just to get the same result

Signed-off-by: Robin Appelman <robin@icewind.nl>