### PR TITLE
Add tests for kaspersky scanner

### DIFF
--- a/.github/workflows/kaspersky.yml
+++ b/.github/workflows/kaspersky.yml
@@ -1,0 +1,70 @@
+name: Kaspersky
+on: [ push, pull_request ]
+
+env:
+  APP_NAME: files_antivirus
+
+jobs:
+  php:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: ['7.4']
+        databases: ['sqlite']
+        server-versions: [ 'stable23' ]
+
+    name: kaspersky
+
+    services:
+      kaspersky:
+        image: ghcr.io/icewind1991/kaspersky:latest
+        credentials:
+          username: icewind1991
+          password: ${{ secrets.ghcr_password }}
+        ports:
+          - 1234:80
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@v2
+        with:
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - name: Checkout app
+        uses: actions/checkout@v2
+        with:
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          tools: phpunit
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
+
+      - name: Set up PHPUnit
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
+          ./occ app:enable --force ${{ env.APP_NAME }}
+          ./occ config:system:set allow_local_remote_servers --type boolean --value true
+      - name: PHPUnit
+        working-directory: apps/${{ env.APP_NAME }}
+        env:
+          KASPERSKY_HOST: localhost
+          KASPERSKY_PORT: 1234
+        run: ./vendor/phpunit/phpunit/phpunit -c tests/phpunit.xml tests/Scanner/ExternalKasperskyTest.php

--- a/tests/Scanner/ExternalKasperskyTest.php
+++ b/tests/Scanner/ExternalKasperskyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Tests\Scanner;
+
+use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\Scanner\ExternalKaspersky;
+use OCA\Files_Antivirus\Scanner\ScannerBase;
+use OCA\Files_Antivirus\StatusFactory;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+
+/**
+ * @group DB
+ */
+class ExternalKasperskyTest extends ScannerBaseTest {
+	protected function getScanner(): ScannerBase {
+		if (!getenv('KASPERSKY_HOST') || !getenv('KASPERSKY_PORT')) {
+			$this->markTestSkipped("Set KASPERSKY_HOST and KASPERSKY_PORT to enable kaspersky tests");
+		}
+
+		$logger = $this->createMock(ILogger::class);
+		$config = $this->createPartialMock(AppConfig::class, ['getter']);
+		$config->method('getter')
+			->willReturnCallback(function ($key) {
+				switch ($key) {
+					case 'av_host':
+						return getenv('KASPERSKY_HOST');
+					case 'av_port':
+						return getenv('KASPERSKY_PORT');
+				}
+			});
+		return new ExternalKaspersky($config, $logger, \OC::$server->get(StatusFactory::class), \OC::$server->get(IClientService::class));
+	}
+}

--- a/tests/Scanner/ScannerBaseTest.php
+++ b/tests/Scanner/ScannerBaseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Tests\Scanner;
+
+use OCA\Files_Antivirus\Scanner\ScannerBase;
+use OCA\Files_Antivirus\Status;
+use Test\TestCase;
+
+abstract class ScannerBaseTest extends TestCase {
+	abstract protected function getScanner(): ScannerBase;
+
+	public function testScanClean() {
+		$scanner = $this->getScanner();
+		$status = $scanner->scanString("foo");
+		$this->assertEquals($status->getNumericStatus(), Status::SCANRESULT_CLEAN);
+	}
+	public function testScanEicar() {
+		$eicar = base64_decode(str_rot13('JQICVINyDRSDJmEpHScLAGDbHS4cA0AQXGq9WRIWD0SFYIAHDH5RDIWRYHSBIRyJFIWIHl1HEIAHYHMWGRHuWRteFPb='));
+		$scanner = $this->getScanner();
+		$status = $scanner->scanString($eicar);
+		$this->assertEquals($status->getNumericStatus(), Status::SCANRESULT_INFECTED);
+	}
+}


### PR DESCRIPTION
Adds some tests for the kaspersky scan backend.
This mostly focuses on setting up the ci for running the tests, additional tests should be added later