### PR TITLE
No rule match: Log sanitised raw stream response

### DIFF
--- a/lib/Status.php
+++ b/lib/Status.php
@@ -113,7 +113,13 @@ class Status {
 			
 			if (!$isMatched) {
 				$this->numericStatus = self::SCANRESULT_UNCHECKED;
-				$this->details = 'No matching rules. Please check antivirus rules.';
+
+				// Adding the ASCII text range 32..126 (excluding '`') of the raw socket response to the details.
+				$response = filter_var($rawResponse, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH | FILTER_FLAG_STRIP_BACKTICK);
+				if (strlen($response) > 512) {
+					$response = substr($response, 0, 509) . "...";
+				}
+				$this->details = 'No matching rule for response [' . $response . ']. Please check antivirus rules configuration.';
 			}
 		} else { // Executable mode
 			$scanStatus = $this->ruleMapper->findByResult($result);


### PR DESCRIPTION
This PR enhances logs for the case that the response in socket mode does not match the regex of any of the configured rules.

Prior to this change, such cases result in a log message like this:
````
Not Checked. No matching rules. Please check antivirus rules. File: ...
````

After the change:
````
Not Checked. No matching rule for response [the actual response from clamav via socket]. Please check antivirus rules configuration. File: ...
````

This may not fix cases like #110 but it would make it more straight forward to find the issue.