### PR TITLE
Fix lint checks on PHP 7.3 CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4', '8.0']
+        ocp-version: ['^v21.0.0', '^v22.0.0', '^v23.0.0', 'dev-master']
     name: php${{ matrix.php-versions }} lint
     steps:
     - name: Checkout
@@ -23,6 +24,9 @@ jobs:
         coverage: none
     - name: Install dependencies
       run: composer i
+    - name: Install OCP package
+      if: ${{ matrix.php-versions != '7.3' }}
+      run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
     - name: Lint
       run: composer run lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,21 +11,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-version: ['7.3', '7.4', '8.0']
         ocp-version: ['^v21.0.0', '^v22.0.0', '^v23.0.0', 'dev-master']
-    name: php${{ matrix.php-versions }} lint
+    name: php${{ matrix.php-version }} lint
     steps:
     - name: Checkout
       uses: actions/checkout@master
     - name: Set up php${{ matrix.php-versons }}
       uses: shivammathur/setup-php@master
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-version }}
         coverage: none
     - name: Install dependencies
+      if: ${{ matrix.php-version != '8.0' }}
       run: composer i
+    - name: Install dependencies
+      if: ${{ matrix.php-version == '8.0' }}
+      run: composer i --ignore-platform-reqs
     - name: Install OCP package
-      if: ${{ matrix.php-versions != '7.3' }}
+      if: ${{ matrix.php-version != '7.3' }}
       run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
     - name: Lint
       run: composer run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       run: composer i --ignore-platform-reqs
     - name: Install OCP package
       if: ${{ matrix.php-version != '7.3' }}
-      run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
+      run: composer require --dev --with-all-dependencies christophwurst/nextcloud:${{ matrix.ocp-version }}
     - name: Lint
       run: composer run lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Set up php${{ matrix.php-versons }}
+    - name: Set up php${{ matrix.php-version }}
       uses: shivammathur/setup-php@master
       with:
         php-version: ${{ matrix.php-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,9 @@ jobs:
     - name: Install dependencies
       run: composer i --ignore-platform-reqs
     - name: Install OCP package
-      run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
+      run: |
+        rm composer.lock
+        composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
     - name: Lint
       run: composer run lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0']
+        php-version: ['7.4', '8.0']
         ocp-version: ['^v21.0.0', '^v22.0.0', '^v23.0.0', 'dev-master']
-    name: php${{ matrix.php-version }} lint
+        include:
+          - php-version: '7.3'
+            ocp-version: '^v21.0.0'
+          - php-version: '7.3'
+            ocp-version: '^v22.0.0'
+          - php-version: '7.3'
+            ocp-version: '^v23.0.0'
+          - php-version: '8.1'
+            ocp-version: 'dev-master'
+    name: php${{ matrix.php-version }}-ocp-${{ matrix.ocp-version }} lint
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -23,14 +32,9 @@ jobs:
         php-version: ${{ matrix.php-version }}
         coverage: none
     - name: Install dependencies
-      if: ${{ matrix.php-version != '8.0' }}
-      run: composer i
-    - name: Install dependencies
-      if: ${{ matrix.php-version == '8.0' }}
       run: composer i --ignore-platform-reqs
     - name: Install OCP package
-      if: ${{ matrix.php-version != '7.3' }}
-      run: composer require --dev --with-all-dependencies christophwurst/nextcloud:${{ matrix.ocp-version }}
+      run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
     - name: Lint
       run: composer run lint
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"christophwurst/nextcloud": "dev-master",
+		"christophwurst/nextcloud": "^v20.0.0",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpunit/phpunit": "^8",
 		"nextcloud/coding-standard": "^0.4.0"


### PR DESCRIPTION
OCP package `christophwurst/nextcloud` is set to `^20.0.0`, the [minimum supported version](https://github.com/nextcloud/files_antivirus/blob/3c529388fa55f078ccb9f80645d76c456c5815bc/appinfo/info.xml#L47) of the app

An OCP version matrix is also added to lint against newer versions