### PR TITLE
Clarify intention of blocking uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * :chipmunk: When the user uploads a file, it's checked
 * :biohazard: Infected files will be deleted and a notification will be shown and/or sent via email 
 * :mag_right: It runs a background job to scan all files
+* :safety_vest: It will block all uploads if the file cannot be checked to ensure all files are getting scanned.
 
 ## Requirements
 


### PR DESCRIPTION
When files cannot be checked for any reason uploads are blocked.
Make sure this intention is clear from the Readme.

Signed-off-by: Max <max@nextcloud.com>