### PR TITLE
Handle encryption error

### DIFF
--- a/lib/Scanner/ScannerBase.php
+++ b/lib/Scanner/ScannerBase.php
@@ -111,8 +111,14 @@ abstract class ScannerBase implements IScanner {
 	public function scan(Item $item): Status {
 		$this->initScanner();
 
-		while (false !== ($chunk = $item->fread())) {
-			$this->writeChunk($chunk);
+		try {
+			while (false !== ($chunk = $item->fread())) {
+				$this->writeChunk($chunk);
+			}
+		} catch (\OCP\Encryption\Exceptions\GenericEncryptionException $e) {
+			// We can't read the file, ignore
+			$this->status->setNumericStatus(Status::SCANRESULT_CLEAN);
+			return $this->getStatus();
 		}
 
 		$this->shutdownScanner();

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -40,6 +40,11 @@ namespace {
 	}
 }
 
+namespace OC {
+    class HintException extends \Exception {
+    }
+}
+
 namespace OC\Hooks {
 	class Emitter {
 	}


### PR DESCRIPTION
When we can't read a file due to some encryption issue, just abort instead
of trying again and againt to read it.
