### PR TITLE
Update link to Kaspersky session timeout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This app can be configured to work with the executable or the daemon mode (recom
 
 ## Kaspersky HTTP Details
 
-When running Kaspersky in HTTP mode the [`SessionTimeout`](https://support.kaspersky.com/ScanEngine/1.0/en-US/201030.htm) will need to be set to a value higher than default, a value of 10 minutes (600000 millisecond) or higher is recommended to properly deal with larger uploads
+When running Kaspersky in HTTP mode the [`SessionTimeout`](https://support.kaspersky.com/ScanEngine/2.1/en-US/201030.htm) will need to be set to a value higher than default, a value of 10 minutes (600000 millisecond) or higher is recommended to properly deal with larger uploads
 
 ## ICAP (version 4.0 and later)
 


### PR DESCRIPTION
https://support.kaspersky.com/help/ScanEngine/1.0/en-US/179870.htm exists as well but is for the old version.