### PR TITLE
Fix type of scan timeout

### DIFF
--- a/lib/Scanner/ExternalKaspersky.php
+++ b/lib/Scanner/ExternalKaspersky.php
@@ -81,7 +81,7 @@ class ExternalKaspersky extends ScannerBase {
 		$body = base64_encode($body);
 		$response = $this->clientService->newClient()->post("$avHost:$avPort/api/v3.0/scanmemory", [
 			'json' => [
-				'timeout' => 60000,
+				'timeout' => "60000",
 				'object' => $body,
 			],
 			'connect_timeout' => 5,


### PR DESCRIPTION
int -> string

https://support.kaspersky.com/ScanEngine/2.1/en-US/193000.htm
