### PR TITLE
Fix deprecated "jsonSerialize()" return type in PHP 8.1

### DIFF
--- a/lib/Db/Rule.php
+++ b/lib/Db/Rule.php
@@ -81,7 +81,7 @@ class Rule extends Entity implements JsonSerializable {
 	 * Pack data into json
 	 * @return array
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
 			'group_id' => $this->groupId,


### PR DESCRIPTION
Fixes #258

In PHP 8.1 the return type of `jsonSerialize()` was set to `mixed`, and a "deprecated" notice is raised if subclasses do not declare any return type. `mixed` was added in PHP 8.0, but the return type of a method can have a more specific type in a subclass than in the parent class (https://wiki.php.net/rfc/mixed_type_v2), so `array` can be used to solve the deprecated notice while also being compatible with PHP 7.4.

## How to test

- Use PHP 8.1
- Maybe set `error_reporting` to `E_ALL` in `/etc/php/8.1/...` for your web server (`find /etc/php -type f -exec grep -Hn error_reporting {} \;`)
- [Setup antivirus app with ClamAV in daemon (socket) mode](https://docs.nextcloud.com/server/25/admin_manual/configuration_server/antivirus_configuration.html)
  - `apt-get install clamav clamav-daemon` (or equivalent for your distribution)
  - `freshclam`
  - `service clamav-daemon start`
  - Enable `files_antivirus` in Nextcloud
  - In Security administration settings, set the mode of the antivirus to `ClamAV Daemon (socket)`
  - Open the advanced settings so the rules are set
  - Save the settings
- (Showing the settings should have been enough to raise the notice, but the following steps are the typical scenario that raises it)
- Create a public upload folder
- As a guest, upload a file

### Result with this pull request

No errors are shown in Nextcloud log

### Result without this pull request

`Return type of OCA\Files_Antivirus\Db\Rule::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice` is shown in Nextcloud log
