### PR TITLE
add commands for working with (background) scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [5.1.0] - 2023-05-17
 ## Added
+* Add command to get background scanner status: `occ files_antvirus:status`
+* Add command to trigger the background scanner: `occ files_antivirus:background-scan`
+* Add command to manually scan a single file: `occ files_antivirus:scan`
+* Add command to mark a file as scanner or unscanned: `occ files_antivirus:mark`
+
+## [5.1.1] - 2023-06-15
+## Fixed
+* Fix compatibility with php 7.4
+
+## [5.1.0] - 2023-05-17
+## Added
 * Support for Nextcloud 27
 
 ## [4.0.1] - 2022-12-06

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,6 +63,7 @@ For this app to be effective, the ClamAV virus definitions should be kept up to 
 	<commands>
 		<command>OCA\Files_Antivirus\Command\Status</command>
 		<command>OCA\Files_Antivirus\Command\BackgroundScan</command>
+		<command>OCA\Files_Antivirus\Command\Scan</command>
 	</commands>
 
 	<settings>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 This application inspects files that are uploaded to Nextcloud for viruses before they are written to the Nextcloud storage. If a file is identified as a virus, it is either logged or not uploaded to the server. The application relies on the underlying ClamAV virus scanning engine, which the admin points Nextcloud to when configuring the application. Alternatively, a Kaspersky Scan Engine can be configured, which has to run on a separate server.
 For this app to be effective, the ClamAV virus definitions should be kept up to date. Also note that enabling this app will impact system performance as additional processing is required for every upload. More information is available in the Antivirus documentation.
 	]]></description>
-	<version>5.1.1</version>
+	<version>5.2.0</version>
 	<licence>agpl</licence>
 
 	<author>Manuel Delgado</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,6 +64,7 @@ For this app to be effective, the ClamAV virus definitions should be kept up to 
 		<command>OCA\Files_Antivirus\Command\Status</command>
 		<command>OCA\Files_Antivirus\Command\BackgroundScan</command>
 		<command>OCA\Files_Antivirus\Command\Scan</command>
+		<command>OCA\Files_Antivirus\Command\Mark</command>
 	</commands>
 
 	<settings>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -60,6 +60,11 @@ For this app to be effective, the ClamAV virus definitions should be kept up to 
 		</install>
 	</repair-steps>
 
+	<commands>
+		<command>OCA\Files_Antivirus\Command\Status</command>
+		<command>OCA\Files_Antivirus\Command\BackgroundScan</command>
+	</commands>
+
 	<settings>
 		<admin>OCA\Files_Antivirus\Settings\Admin</admin>
 	</settings>

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -211,7 +211,7 @@ class BackgroundScanner extends TimedJob {
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while (($fileId = $result->fetchOne()) !== false) {
 			yield $fileId;
 		}
@@ -231,7 +231,7 @@ class BackgroundScanner extends TimedJob {
 			->andWhere($this->getSizeLimitExpression($qb))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		while (($fileId = $result->fetchOne()) !== false) {
 			yield (int)$fileId;
 		}
@@ -258,7 +258,7 @@ class BackgroundScanner extends TimedJob {
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while (($fileId = $result->fetchOne()) !== false) {
 			yield $fileId;
 		}

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -10,19 +10,19 @@ declare(strict_types=1);
 
 namespace OCA\Files_Antivirus\BackgroundJob;
 
-use OCA\Files_Antivirus\Event\BeforeBackgroundScanEvent;
-use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Config\IUserMountCache;
-use OCP\Files\Node;
 use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\Event\BeforeBackgroundScanEvent;
 use OCA\Files_Antivirus\ItemFactory;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 
@@ -195,7 +195,7 @@ class BackgroundScanner extends TimedJob {
 	}
 
 	/**
-	 * @return iterable<int>
+	 * @return \Iterator<int>
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getUnscannedFiles() {
@@ -219,7 +219,7 @@ class BackgroundScanner extends TimedJob {
 
 
 	/**
-	 * @return iterable<int>
+	 * @return \Iterator<int>
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getToRescanFiles() {
@@ -239,7 +239,7 @@ class BackgroundScanner extends TimedJob {
 
 
 	/**
-	 * @return iterable<int>
+	 * @return \Iterator<int>
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getOutdatedFiles() {

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -10,6 +10,10 @@ declare(strict_types=1);
 
 namespace OCA\Files_Antivirus\BackgroundJob;
 
+use OCA\Files_Antivirus\Event\BeforeBackgroundScanEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\IUserMountCache;
+use OCP\Files\Node;
 use OCA\Files_Antivirus\AppConfig;
 use OCA\Files_Antivirus\ItemFactory;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
@@ -20,8 +24,6 @@ use OCP\Files\File;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
-use OCP\IUser;
-use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class BackgroundScanner extends TimedJob {
@@ -29,10 +31,11 @@ class BackgroundScanner extends TimedJob {
 	private ScannerFactory $scannerFactory;
 	private AppConfig $appConfig;
 	protected LoggerInterface $logger;
-	protected IUserManager $userManager;
 	protected IDBConnection $db;
 	protected IMimeTypeLoader $mimeTypeLoader;
 	protected ItemFactory $itemFactory;
+	private IUserMountCache $userMountCache;
+	private IEventDispatcher $eventDispatcher;
 	private bool $isCLI;
 
 	public function __construct(
@@ -41,10 +44,11 @@ class BackgroundScanner extends TimedJob {
 		AppConfig $appConfig,
 		IRootFolder $rootFolder,
 		LoggerInterface $logger,
-		IUserManager $userManager,
 		IDBConnection $db,
 		IMimeTypeLoader $mimeTypeLoader,
 		ItemFactory $itemFactory,
+		IUserMountCache $userMountCache,
+		IEventDispatcher $eventDispatcher,
 		bool $isCLI
 	) {
 		parent::__construct($timeFactory);
@@ -52,10 +56,11 @@ class BackgroundScanner extends TimedJob {
 		$this->scannerFactory = $scannerFactory;
 		$this->appConfig = $appConfig;
 		$this->logger = $logger;
-		$this->userManager = $userManager;
 		$this->db = $db;
 		$this->mimeTypeLoader = $mimeTypeLoader;
 		$this->itemFactory = $itemFactory;
+		$this->userMountCache = $userMountCache;
+		$this->eventDispatcher = $eventDispatcher;
 		$this->isCLI = $isCLI;
 
 		// Run once per 15 minutes
@@ -71,156 +76,100 @@ class BackgroundScanner extends TimedJob {
 			$this->logger->debug('Antivirus background scan disabled, skipping');
 			return;
 		}
+		$remaining = $this->getBatchSize();
+		$this->scan($remaining);
+	}
 
+	public function scan(int $max): int {
+		$count = 0;
 		// locate files that are not checked yet
 		try {
-			$result = $this->getUnscannedFiles();
+			$unscanned = $this->getUnscannedFiles();
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			return;
+			return 0;
 		}
 
+		$unscanned = new \LimitIterator($unscanned, 0, $max);
 		$this->logger->debug('Start background scan');
-		$batchSize = $this->getBatchSize();
 
 		// Run for unscanned files
-		$cnt = 0;
-		while (($row = $result->fetch()) && $cnt < $batchSize) {
-			try {
-				$fileId = $row['fileid'];
-				$users = $this->getUserWithAccessToStorage((int)$row['storage']);
+		$count += $this->processFiles($unscanned);
 
-				foreach ($users as $user) {
-					/** @var IUser $owner */
-					$owner = $this->userManager->get($user['user_id']);
-					if (!$owner instanceof IUser) {
-						continue;
-					}
-
-					$userFolder = $this->rootFolder->getUserFolder($owner->getUID());
-					$files = $userFolder->getById($fileId);
-
-					if ($files === []) {
-						continue;
-					}
-
-					$file = array_pop($files);
-					if ($file instanceof File) {
-						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
-							$this->scanOneFile($file);
-						}
-					} else {
-						$this->logger->error('Tried to scan non file');
-					}
-
-					// increased only for successfully scanned files
-					$cnt++;
-					break;
-				}
-			} catch (\Exception $e) {
-				$this->logger->error($e->getMessage(), ['exception' => $e]);
-			}
-		}
-
-		if ($cnt === $batchSize) {
+		if ($count >= $max) {
 			// we are done
-			return;
+			return $count;
 		}
 
 		// Run for updated files
 		try {
-			$result = $this->getToRescanFiles();
+			$rescan = $this->getToRescanFiles();
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			return;
+			return $count;
 		}
 
-		while (($row = $result->fetch()) && $cnt < $batchSize) {
-			try {
-				$fileId = $row['fileid'];
-				$users = $this->getUserWithAccessToStorage((int)$row['storage']);
+		$rescan = new \LimitIterator($rescan, 0, $max - $count);
+		$count += $this->processFiles($rescan);
 
-				foreach ($users as $user) {
-					/** @var IUser $owner */
-					$owner = $this->userManager->get($user['user_id']);
-					if (!$owner instanceof IUser) {
-						continue;
-					}
-
-					$userFolder = $this->rootFolder->getUserFolder($owner->getUID());
-					$files = $userFolder->getById($fileId);
-
-					if ($files === []) {
-						continue;
-					}
-
-					$file = array_pop($files);
-
-					if ($file instanceof File) {
-						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
-							$this->scanOneFile($file);
-						}
-					} else {
-						$this->logger->error('Tried to scan non file');
-					}
-
-					// increased only for successfully scanned files
-					$cnt++;
-					break;
-				}
-			} catch (\Exception $e) {
-				$this->logger->error(__METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus', 'exception' => $e]);
-			}
+		if ($count >= $max) {
+			// we are done
+			return $count;
 		}
-
 
 		// Run for files that have been scanned in the past. Just start to rescan them as the virus definitions might have been updated
 		try {
-			$result = $this->getOutdatedFiles();
+			$outdated = $this->getOutdatedFiles();
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			return;
+			return $count;
 		}
 
-		while (($row = $result->fetch()) && $cnt < $batchSize) {
+		$outdated = new \LimitIterator($outdated, 0, $max - $count);
+		$this->processFiles($outdated);
+
+		return $count;
+	}
+
+	/**
+	 * @param iterable<int> $fileIds
+	 * @return int
+	 */
+	private function processFiles(iterable $fileIds): int {
+		$count = 0;
+		foreach ($fileIds as $fileId) {
 			try {
-				$fileId = $row['fileid'];
-				$users = $this->getUserWithAccessToStorage((int)$row['storage']);
-
-				foreach ($users as $user) {
-					/** @var IUser $owner */
-					$owner = $this->userManager->get($user['user_id']);
-					if (!$owner instanceof IUser) {
-						continue;
-					}
-
-					$userFolder = $this->rootFolder->getUserFolder($owner->getUID());
-					$files = $userFolder->getById($fileId);
-
-					if ($files === []) {
-						continue;
-					}
-
-					$file = array_pop($files);
-					if ($file instanceof File) {
-						if ($userFolder->nodeExists($userFolder->getRelativePath($file->getPath()))) {
-							$this->scanOneFile($file);
-						}
-					} else {
-						$this->logger->error('Tried to scan non file');
-					}
-
+				$file = $this->getNodeForFile($fileId);
+				if ($file instanceof File) {
+					$this->scanOneFile($file);
 					// increased only for successfully scanned files
-					$cnt++;
-					break;
+					$count++;
+				} else {
+					$this->logger->error('Tried to scan non file');
 				}
 			} catch (\Exception $e) {
 				$this->logger->error(__METHOD__ . ', exception: ' . $e->getMessage(), ['app' => 'files_antivirus', 'exception' => $e]);
 			}
 		}
+		return $count;
 	}
 
-	protected function getBatchSize(): int {
+	public function getNodeForFile(int $fileId): ?Node {
+		$cachedMounts = $this->userMountCache->getMountsForFileId($fileId);
+
+		foreach ($cachedMounts as $cachedMount) {
+			$userFolder = $this->rootFolder->getUserFolder($cachedMount->getUser()->getUID());
+			$nodes = $userFolder->getById($fileId);
+			foreach ($nodes as $node) {
+				if ($node->isReadable()) {
+					return $node;
+				}
+			}
+		}
+		return null;
+	}
+
+	public function getBatchSize(): int {
 		$batchSize = 10;
 		if ($this->isCLI) {
 			$batchSize = 100;
@@ -245,24 +194,15 @@ class BackgroundScanner extends TimedJob {
 		return $sizeLimitExpr;
 	}
 
-	protected function getUserWithAccessToStorage(int $storageId): array {
-		$qb = $this->db->getQueryBuilder();
-
-		$qb->select('user_id')
-			->from('mounts')
-			->where($qb->expr()->eq('storage_id', $qb->createNamedParameter($storageId)));
-
-		$cursor = $qb->execute();
-		$data = $cursor->fetchAll();
-		$cursor->closeCursor();
-		return $data;
-	}
-
+	/**
+	 * @return iterable<int>
+	 * @throws \OCP\DB\Exception
+	 */
 	public function getUnscannedFiles() {
 		$dirMimeTypeId = $this->mimeTypeLoader->getId('httpd/unix-directory');
 
 		$query = $this->db->getQueryBuilder();
-		$query->select('fc.fileid', 'storage')
+		$query->select('fc.fileid')
 			->from('filecache', 'fc')
 			->leftJoin('fc', 'files_antivirus', 'fa', $query->expr()->eq('fc.fileid', 'fa.fileid'))
 			->where($query->expr()->isNull('fa.fileid'))
@@ -271,21 +211,37 @@ class BackgroundScanner extends TimedJob {
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		return $query->execute();
+		$result = $query->execute();
+		while (($fileId = $result->fetchOne()) !== false) {
+			yield $fileId;
+		}
 	}
 
-	protected function getToRescanFiles() {
+
+	/**
+	 * @return iterable<int>
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getToRescanFiles() {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('fc.fileid', 'fc.storage')
+		$qb->select('fc.fileid')
 			->from('filecache', 'fc')
 			->join('fc', 'files_antivirus', 'fa', $qb->expr()->eq('fc.fileid', 'fa.fileid'))
 			->andWhere($qb->expr()->lt('fa.check_time', 'fc.mtime'))
 			->andWhere($this->getSizeLimitExpression($qb))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		return $qb->execute();
+		$result = $qb->execute();
+		while (($fileId = $result->fetchOne()) !== false) {
+			yield (int)$fileId;
+		}
 	}
 
+
+	/**
+	 * @return iterable<int>
+	 * @throws \OCP\DB\Exception
+	 */
 	public function getOutdatedFiles() {
 		$dirMimeTypeId = $this->mimeTypeLoader->getId('httpd/unix-directory');
 
@@ -293,7 +249,7 @@ class BackgroundScanner extends TimedJob {
 		$yesterday = time() - (28 * 24 * 60 * 60);
 
 		$query = $this->db->getQueryBuilder();
-		$query->select('fc.fileid', 'fc.storage')
+		$query->select('fc.fileid')
 			->from('filecache', 'fc')
 			->innerJoin('fc', 'files_antivirus', 'fa', $query->expr()->eq('fc.fileid', 'fa.fileid'))
 			->andWhere($query->expr()->neq('mimetype', $query->createNamedParameter($dirMimeTypeId)))
@@ -302,11 +258,15 @@ class BackgroundScanner extends TimedJob {
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 
-		return $query->execute();
+		$result = $query->execute();
+		while (($fileId = $result->fetchOne()) !== false) {
+			yield $fileId;
+		}
 	}
 
 	protected function scanOneFile(File $file): void {
 		$this->logger->debug('Scanning file with fileid: ' . $file->getId());
+		$this->eventDispatcher->dispatchTyped(new BeforeBackgroundScanEvent($file));
 
 		$item = $this->itemFactory->newItem($file, true);
 		$scanner = $this->scannerFactory->getScanner();

--- a/lib/Command/BackgroundScan.php
+++ b/lib/Command/BackgroundScan.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2023 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -80,28 +80,5 @@ class BackgroundScan extends Base {
 		}
 
 		return 0;
-	}
-
-	/**
-	 * @param iterable<int> $fileIds
-	 * @return int
-	 */
-	private function processFiles(iterable $fileIds, OutputInterface $output, bool $verbose, string $info): int {
-		$count = 0;
-
-		foreach ($fileIds as $fileId) {
-			if ($verbose) {
-				$node = $this->backgroundScanner->getNodeForFile($fileId);
-				if ($node) {
-					$path = $node->getPath();
-					$output->writeln("  <info>$fileId></info> at <info>$path</info> $info");
-				} else {
-					$output->writeln("  <error>warning: no file found for file $fileId</error>");
-				}
-			}
-			$count++;
-		}
-
-		return $count;
 	}
 }

--- a/lib/Command/BackgroundScan.php
+++ b/lib/Command/BackgroundScan.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Command;
+
+use OC\Core\Command\Base;
+use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\BackgroundJob\BackgroundScanner;
+use OCA\Files_Antivirus\Event\BeforeBackgroundScanEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BackgroundScan extends Base {
+	private BackgroundScanner $backgroundScanner;
+	private AppConfig $appConfig;
+	private IEventDispatcher $eventDispatcher;
+
+	public function __construct(AppConfig $appConfig, BackgroundScanner $backgroundScanner, IEventDispatcher $eventDispatcher) {
+		parent::__construct();
+		$this->backgroundScanner = $backgroundScanner;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->appConfig = $appConfig;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('files_antivirus:background-scan')
+			->setDescription('Run the background scan')
+			->addOption('max', 'm', InputOption::VALUE_REQUIRED, "Maximum number of files to process");
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$verbose = (bool)$input->getOption('verbose');
+		if ($this->appConfig->getAppValue('av_background_scan') !== 'on') {
+			// Background checking disabled no need to continue
+			$output->writeln('Antivirus background scan disabled');
+			return 0;
+		}
+		$max = (int)$input->getOption('max');
+		if (!$max) {
+			$max = PHP_INT_MAX;
+		}
+
+		if ($verbose) {
+			$this->eventDispatcher->addListener(BeforeBackgroundScanEvent::class, function (BeforeBackgroundScanEvent $event) use ($output) {
+				$path = $event->getFile()->getPath();
+				$output->writeln("scanning <info>$path</info>");
+			});
+		}
+
+		$count = $this->backgroundScanner->scan($max);
+
+		$output->writeln("scanned <info>$count</info> files");
+		if ($count === $max) {
+			$output->writeln("  there might still be unscanned files remaining");
+		}
+
+		return 0;
+	}
+
+	/**
+	 * @param iterable<int> $fileIds
+	 * @return int
+	 */
+	private function processFiles(iterable $fileIds, OutputInterface $output, bool $verbose, string $info): int {
+		$count = 0;
+
+		foreach ($fileIds as $fileId) {
+			if ($verbose) {
+				$node = $this->backgroundScanner->getNodeForFile($fileId);
+				if ($node) {
+					$path = $node->getPath();
+					$output->writeln("  <info>$fileId></info> at <info>$path</info> $info");
+				} else {
+					$output->writeln("  <error>warning: no file found for file $fileId</error>");
+				}
+			}
+			$count++;
+		}
+
+		return $count;
+	}
+}

--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Command;
+
+use OC\Core\Command\Base;
+use OCA\Files_Antivirus\ItemFactory;
+use OCA\Files_Antivirus\Scanner\ScannerFactory;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Scan extends Base {
+	private ScannerFactory $scannerFactory;
+	private IRootFolder $rootFolder;
+	private ItemFactory $itemFactory;
+
+	public function __construct(
+		IRootFolder $rootFolder,
+		ScannerFactory $scannerFactory,
+		ItemFactory $itemFactory
+	) {
+		parent::__construct();
+		$this->rootFolder = $rootFolder;
+		$this->scannerFactory = $scannerFactory;
+		$this->itemFactory = $itemFactory;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('files_antivirus:scan')
+			->setDescription('Scan a file')
+		->addArgument('file', InputArgument::REQUIRED, "Path of the file to scan");
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$path = $input->getArgument('file');
+		try {
+			$node = $this->rootFolder->get($path);
+		} catch (NotFoundException $e) {
+			$output->writeln("<error>$path doesn't exist</error>");
+			return 3;
+		}
+		if (!$node instanceof File) {
+			$output->writeln("<error>$path is a folder</error>");
+			return 3;
+		}
+
+		$scanner = $this->scannerFactory->getScanner();
+		$item = $this->itemFactory->newItem($node);
+		$result = $scanner->scan($item);
+
+		switch ($result->getNumericStatus()) {
+			case \OCA\Files_Antivirus\Status::SCANRESULT_UNCHECKED:
+				$status = "couldn't be scanned";
+				$exit = 2;
+				break;
+			case \OCA\Files_Antivirus\Status::SCANRESULT_CLEAN:
+				$status = "is <info>clean</info>";
+				$exit = 0;
+				break;
+			case \OCA\Files_Antivirus\Status::SCANRESULT_INFECTED:
+				$status = "is <error>infected</error>";
+				$exit = 1;
+				break;
+		}
+		if ($result->getDetails()) {
+			$details = ": " . $result->getDetails();
+		} else {
+			$details = "";
+		}
+		$output->writeln("<info>$path</info> $status$details");
+
+		return $exit;
+	}
+
+	/**
+	 * @param iterable<int> $fileIds
+	 * @return int
+	 */
+	private function processFiles(iterable $fileIds, OutputInterface $output, bool $verbose, string $info): int {
+		$count = 0;
+
+		foreach ($fileIds as $fileId) {
+			if ($verbose) {
+				$node = $this->backgroundScanner->getNodeForFile($fileId);
+				if ($node) {
+					$path = $node->getPath();
+					$output->writeln("  <info>$path</info> $info");
+				} else {
+					$output->writeln("  <error>warning: no file found for file $fileId</error>");
+				}
+			}
+			$count++;
+		}
+
+		return $count;
+	}
+}

--- a/lib/Command/Status.php
+++ b/lib/Command/Status.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2023 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Command/Status.php
+++ b/lib/Command/Status.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Command;
+
+use OC\Core\Command\Base;
+use OCA\Files_Antivirus\AppConfig;
+use OCA\Files_Antivirus\BackgroundJob\BackgroundScanner;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Status extends Base {
+	private BackgroundScanner $backgroundScanner;
+	private AppConfig $appConfig;
+
+	public function __construct(AppConfig $appConfig, BackgroundScanner $backgroundScanner) {
+		parent::__construct();
+		$this->backgroundScanner = $backgroundScanner;
+		$this->appConfig = $appConfig;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('files_antivirus:status')
+			->setDescription('Antivirus scanner status');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$verbose = (bool)$input->getOption('verbose');
+		if ($this->appConfig->getAppValue('av_background_scan') !== 'on') {
+			// Background checking disabled no need to continue
+			$output->writeln('Antivirus background scan disabled');
+			return 0;
+		}
+
+		$unscanned = $this->backgroundScanner->getUnscannedFiles();
+		$count = $this->processFiles($unscanned, $output, $verbose, "is unscanned");
+		$output->writeln("$count unscanned files");
+
+		$rescan = $this->backgroundScanner->getToRescanFiles();
+		$count = $this->processFiles($rescan, $output, $verbose, "is scheduled for re-scan");
+		$output->writeln("$count files scheduled for re-scan");
+
+		$outdated = $this->backgroundScanner->getOutdatedFiles();
+		$count = $this->processFiles($outdated, $output, $verbose, "has been updated");
+		$output->writeln("$count have been updated since the last scan");
+
+		return 0;
+	}
+
+	/**
+	 * @param iterable<int> $fileIds
+	 * @return int
+	 */
+	private function processFiles(iterable $fileIds, OutputInterface $output, bool $verbose, string $info): int {
+		$count = 0;
+
+		foreach ($fileIds as $fileId) {
+			if ($verbose) {
+				$node = $this->backgroundScanner->getNodeForFile($fileId);
+				if ($node) {
+					$path = $node->getPath();
+					$output->writeln("  <info>$path</info> $info");
+				} else {
+					$output->writeln("  <error>warning: no file found for file $fileId</error>");
+				}
+			}
+			$count++;
+		}
+
+		return $count;
+	}
+}

--- a/lib/Event/BeforeBackgroundScanEvent.php
+++ b/lib/Event/BeforeBackgroundScanEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2023 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Antivirus\Event;
+
+use OCP\Files\File;
+use OCP\EventDispatcher\Event;
+
+class BeforeBackgroundScanEvent extends Event {
+	private File $file;
+
+	public function __construct(File $file) {
+		$this->file = $file;
+	}
+
+	public function getFile(): File {
+		return $this->file;
+	}
+}

--- a/lib/Event/BeforeBackgroundScanEvent.php
+++ b/lib/Event/BeforeBackgroundScanEvent.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace OCA\Files_Antivirus\Event;
 
-use OCP\Files\File;
 use OCP\EventDispatcher\Event;
+use OCP\Files\File;
 
 class BeforeBackgroundScanEvent extends Event {
 	private File $file;

--- a/lib/ItemFactory.php
+++ b/lib/ItemFactory.php
@@ -30,6 +30,7 @@ namespace OCA\Files_Antivirus;
 use OCA\Files_Antivirus\Db\ItemMapper;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\App\IAppManager;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use Psr\Log\LoggerInterface;
@@ -41,6 +42,7 @@ class ItemFactory {
 	private LoggerInterface $logger;
 	private IRootFolder $rootFolder;
 	private IAppManager $appManager;
+	private ITimeFactory $clock;
 
 	public function __construct(
 		AppConfig $appConfig,
@@ -48,7 +50,8 @@ class ItemFactory {
 		ItemMapper $itemMapper,
 		LoggerInterface $logger,
 		IRootFolder $rootFolder,
-		IAppManager $appManager
+		IAppManager $appManager,
+		ITimeFactory $clock
 	) {
 		$this->config = $appConfig;
 		$this->activityManager = $activityManager;
@@ -56,6 +59,7 @@ class ItemFactory {
 		$this->logger = $logger;
 		$this->rootFolder = $rootFolder;
 		$this->appManager = $appManager;
+		$this->clock = $clock;
 	}
 
 	public function newItem(File $file, bool $isCron = false): Item {
@@ -67,6 +71,7 @@ class ItemFactory {
 			$this->rootFolder,
 			$this->appManager,
 			$file,
+			$this->clock,
 			$isCron
 		);
 	}

--- a/tests/BackgroundScannerTest.php
+++ b/tests/BackgroundScannerTest.php
@@ -85,7 +85,7 @@ class BackgroundScannerTest extends TestBase {
 		$scanner = \OC::$server->get(BackgroundScanner::class);
 		$newFileId = $this->homeDirectory->newFile("foo", "bar")->getId();
 
-		$outdated = $scanner->getUnscannedFiles()->fetchAll(\PDO::FETCH_COLUMN);
+		$outdated = iterator_to_array($scanner->getUnscannedFiles());
 		$this->assertEquals([$newFileId], $outdated);
 	}
 
@@ -96,11 +96,11 @@ class BackgroundScannerTest extends TestBase {
 		/** @var BackgroundScanner $scanner */
 		$scanner = \OC::$server->get(BackgroundScanner::class);
 
-		$outdated = $scanner->getOutdatedFiles()->fetchAll(\PDO::FETCH_COLUMN);
+		$outdated = iterator_to_array($scanner->getOutdatedFiles());
 		$this->assertEquals([], $outdated);
 
 		$this->updateScannedTime($newFileId, time() - (30 * 24 * 60 * 60));
-		$outdated = $scanner->getOutdatedFiles()->fetchAll(\PDO::FETCH_COLUMN);
+		$outdated = iterator_to_array($scanner->getOutdatedFiles());
 		$this->assertEquals([$newFileId], $outdated);
 	}
 }


### PR DESCRIPTION
- `occ files_antvirus:status [-v]` to get info about files in the scan queue
- `occ files_antivirus:background-scan [-v] [-m MAX]` to manually trigger the background scan
- `occ files_antivirus:scan <path>` to manually scan a single file
- `occ files_antivirus:mark <path> <scanned|unscanned>` to mark a file as scanned/unscanned