### PR TITLE
Add option to scan only part of file

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -30,6 +30,7 @@ use OCP\IConfig;
  * @method null setAvHost(string $avHost)
  * @method null setAvPort(int $avPort)
  * @method null setAvMaxFileSize(int $fileSize)
+ * @method null setAvScanFirstBytes(int $fileSize)
  * @method null setAvCmdOptions(string $avCmdOptions)
  * @method null setAvChunkSize(int $chunkSize)
  * @method null setAvPath(string $avPath)
@@ -63,6 +64,7 @@ class AppConfig {
 		'av_icap_response_header' => 'X-Infection-Found',
 		'av_icap_chunk_size' => '1048576',
 		'av_icap_connect_timeout' => '5',
+		'av_scan_first_bytes' => -1,
 	];
 
 	/**

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -64,7 +64,7 @@ class SettingsController extends Controller {
 		$avInfectedAction,
 		$avStreamMaxLength,
 		$avMaxFileSize,
-        $avScanFirstBytes,
+		$avScanFirstBytes,
 		$avIcapMode,
 		$avIcapRequestService,
 		$avIcapResponseHeader

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -50,6 +50,7 @@ class SettingsController extends Controller {
 	 * @param string $avInfectedAction - action performed on infected files
 	 * @param $avStreamMaxLength - reopen socket after bytes
 	 * @param int $avMaxFileSize - file size limit
+	 * @param int $avScanFirstBytes - scan size limit
 	 * @param string $avIcapMode
 	 * @return JSONResponse
 	 */
@@ -63,6 +64,7 @@ class SettingsController extends Controller {
 		$avInfectedAction,
 		$avStreamMaxLength,
 		$avMaxFileSize,
+        $avScanFirstBytes,
 		$avIcapMode,
 		$avIcapRequestService,
 		$avIcapResponseHeader
@@ -76,6 +78,7 @@ class SettingsController extends Controller {
 		$this->settings->setAvInfectedAction($avInfectedAction);
 		$this->settings->setAvStreamMaxLength($avStreamMaxLength);
 		$this->settings->setAvMaxFileSize($avMaxFileSize);
+		$this->settings->setAvScanFirstBytes($avScanFirstBytes);
 		$this->settings->setAvIcapMode($avIcapMode);
 		$this->settings->setAvIcapRequestService($avIcapRequestService);
 		$this->settings->setAvIcapResponseHeader($avIcapResponseHeader);

--- a/lib/Scanner/ScannerBase.php
+++ b/lib/Scanner/ScannerBase.php
@@ -164,6 +164,11 @@ abstract class ScannerBase implements IScanner {
 			return;
 		}
 
+		$scanFirstBytes = (int)$this->appConfig->getAppValue('av_scan_first_bytes');
+		if ($scanFirstBytes > -1 && $this->byteCount >= $scanFirstBytes) {
+			return;
+		}
+
 		$dataLength = strlen($data);
 		$streamSizeLimit = (int)$this->appConfig->getAvStreamMaxLength();
 		if ($this->byteCount + $dataLength > $streamSizeLimit) {

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -90,6 +90,15 @@ script('files_antivirus', 'settings');
 					</td>
 					<td><label for="av_max_file_size" class="a-left"><?php p($l->t('bytes'))?></label></td>
 				</tr>
+				<tr class="av_scan_first_bytes">
+					<td><label for="av_scan_first_bytes"><?php p($l->t('Check only first bytes of the file, -1 means no limit'));?></label></td>
+					<td>
+						<input type="text" id="av_scan_first_bytes" name="avScanFirstBytes" value="<?php p($_['avScanFirstBytes']); ?>"
+						   title="<?php p($l->t('Check only first bytes of the file, -1 means no limit'));?>"
+						/>
+					</td>
+					<td><label for="av_scan_first_bytes" class="a-left"><?php p($l->t('bytes'))?></label></td>
+				</tr>
 				<tr class="infected_action">
 					<td><label for="av_infected_action"><?php p($l->t('When infected files are found during a background scan'));?></label></td>
 					<td><select id="av_infected_action" name="avInfectedAction"><?php print_unescaped(html_select_options(['only_log' => $l->t('Only log'), 'delete' => $l->t('Delete file')], $_['avInfectedAction'])) ?></select></td>

--- a/tests/Scanner/ExternalKasperskyTest.php
+++ b/tests/Scanner/ExternalKasperskyTest.php
@@ -41,13 +41,15 @@ class ExternalKasperskyTest extends ScannerBaseTest {
 
 		$logger = $this->createMock(LoggerInterface::class);
 		$config = $this->createPartialMock(AppConfig::class, ['getter']);
-		$config->method('getter')
+		$config->method('getAppValue')
 			->willReturnCallback(function ($key) {
 				switch ($key) {
 					case 'av_host':
 						return getenv('KASPERSKY_HOST');
 					case 'av_port':
 						return getenv('KASPERSKY_PORT');
+					case 'av_scan_first_bytes':
+						return -1;
 					default:
 						return '';
 				}

--- a/tests/Scanner/ICAPTest.php
+++ b/tests/Scanner/ICAPTest.php
@@ -40,7 +40,7 @@ class ICAPTest extends ScannerBaseTest {
 
 		$logger = $this->createMock(LoggerInterface::class);
 		$config = $this->createPartialMock(AppConfig::class, ['getter']);
-		$config->method('getter')
+		$config->method('getAppValue')
 			->willReturnCallback(function ($key) {
 				switch ($key) {
 					case 'av_host':
@@ -59,6 +59,8 @@ class ICAPTest extends ScannerBaseTest {
 						return '1048576';
 					case 'av_icap_connect_timeout':
 						return '5';
+					case 'av_scan_first_bytes':
+						return -1;
 				}
 			});
 		return new ICAP($config, $logger, \OC::$server->get(StatusFactory::class));


### PR DESCRIPTION
As described in #288 this PR is to allow us to scan only a small part of the file uploaded instead whole file.

This means that if admin set `av_scan_first_bytes` , for example, to `10485760`, antivirus will check only frist 10MB.

Let me know if i need to change something