### PR TITLE
fix: handle icap responses with no encapsulated headers

### DIFF
--- a/tests/ICAP/ResponseParserTest.php
+++ b/tests/ICAP/ResponseParserTest.php
@@ -35,4 +35,9 @@ class ResponseParserTest extends TestCase {
 		$response = $this->parseResponse(__DIR__ . '/../data/icap/403-response.txt');
 		$this->assertEquals('HTTP/1.1 403 Forbidden', $response->getResponseHeaders()['HTTP_STATUS']);
 	}
+
+	public function testParseNullBody() {
+		$response = $this->parseResponse(__DIR__ . '/../data/icap/null-body.txt');
+		$this->assertEquals([], $response->getResponseHeaders());
+	}
 }

--- a/tests/data/icap/null-body.txt
+++ b/tests/data/icap/null-body.txt
@@ -1,0 +1,3 @@
+ICAP/1.0 200 OK
+Encapsulated: null-body=0
+ISTag: "b9eb4f031598bb0b-1716440776"


### PR DESCRIPTION
Improved handling of ICAP responses