### PR TITLE
Optimize query for unscanned files

### DIFF
--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -208,6 +208,7 @@ class BackgroundScanner extends TimedJob {
 			->from('filecache', 'fc')
 			->leftJoin('fc', 'storages', 's', $query->expr()->eq('fc.storage', 's.numeric_id'))
 			->leftJoin('fc', 'files_antivirus', 'fa', $query->expr()->eq('fc.fileid', 'fa.fileid'))
+			->innerJoin('fc', 'mounts', 'm', $query->expr()->eq('s.numeric_id','m.storage_id'))
 			->where($query->expr()->isNull('fa.fileid'))
 			->andWhere($query->expr()->neq('mimetype', $query->createNamedParameter($dirMimeTypeId)))
 			->andWhere($query->expr()->orX(

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -144,7 +144,7 @@ class BackgroundScanner extends TimedJob {
 					// increased only for successfully scanned files
 					$count++;
 				} else {
-					$this->logger->info('Tried to scan non file');
+					$this->logger->info('Tried to scan non file with Id ' . $fileId);
 					$this->deleteFileCheckTime($fileId);
 				}
 			} catch (\Exception $e) {

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -204,9 +204,9 @@ class BackgroundScanner extends TimedJob {
 		$dirMimeTypeId = $this->mimeTypeLoader->getId(FileInfo::MIMETYPE_FOLDER);
 
 		$query = $this->db->getQueryBuilder();
-		$query->select('fc.fileid')
+		$query->selectDistinct('fc.fileid')
 			->from('filecache', 'fc')
-			->leftJoin('fc', 'storages', 's', $query->expr()->eq('fc.storage', 's.numeric_id'))
+			->innerJoin('fc', 'storages', 's', $query->expr()->eq('fc.storage', 's.numeric_id'))
 			->leftJoin('fc', 'files_antivirus', 'fa', $query->expr()->eq('fc.fileid', 'fa.fileid'))
 			->innerJoin('fc', 'mounts', 'm', $query->expr()->eq('s.numeric_id','m.storage_id'))
 			->where($query->expr()->isNull('fa.fileid'))


### PR DESCRIPTION
If my interpretation of the code in ``BackgroundScanner`` is correct, ``getNodeForFile()`` relies on the existence of an existing mount to determine the ``Node`` for a given ``fileId``. 

Sometimes, this fails. Specifically, this line is returning an empty array.
``$cachedMounts = $this->userMountCache->getMountsForFileId($fileId)``

Tracking this further, I found that no corresponding mount can be found for some ``fileId`` that are present in ``oc_filecache`` when joining ``oc_mounts`` through ``oc_storage``. 

**Why is this even a problem, other than creating many log entries?**

If the number of such entries in ``oc_filecache`` is large then the entire batch contains non-scannable entries, starving the scanning of other entries in ``oc_filecache`` that have a corresponding mount.

My PR proposes to only process files whose ``fileId`` that can be related to an existing mount.


More details:
I have a lot of entries in ``oc_filecache`` that look like this:
```
MariaDB [nextcloud]> select fileid,storage,path,size from oc_filecache where fileid=1044856;
+---------+---------+---------------------------------------------------------------+------+
| fileid  | storage | path                                                          | size |
+---------+---------+---------------------------------------------------------------+------+
| 1044856 |      30 | appdata_ocp617nvaw61/preview/2/7/b/3/b/c/9/667010/256-154.png | 7476 |
+---------+---------+---------------------------------------------------------------+------+
````

These entries correctly relate to an entry in ``oc_storages``:
```
+------------+----------------------------+-----------+--------------+
| numeric_id | id                         | available | last_checked |
+------------+----------------------------+-----------+--------------+
|         30 | local::/var/www/html/data/ |         1 |         NULL |
+------------+----------------------------+-----------+--------------+
```

However, no mount can be found:
```
MariaDB [nextcloud]> select * from oc_mounts where storage_id=30;
Empty set (0.000 sec)
```






