### PR TITLE
Get proper errer message when the connection to an ICAP Server fails

### DIFF
--- a/lib/ICAP/ICAPClient.php
+++ b/lib/ICAP/ICAPClient.php
@@ -51,14 +51,14 @@ class ICAPClient {
 			$errorMessage,
 			$this->connectTimeout
 		);
-
-		socket_set_timeout($stream, 600);
-
+		
 		if (!$stream) {
 			throw new RuntimeException(
 				"Cannot connect to \"tcp://{$this->host}:{$this->port}\": $errorMessage (code $errorCode)"
 			);
 		}
+
+		socket_set_timeout($stream, 600);
 
 		return $stream;
 	}

--- a/tests/ICAP/ICAPClientTest.php
+++ b/tests/ICAP/ICAPClientTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Tests\ICAP;
+
+use OCA\Files_Antivirus\ICAP\ICAPClient;
+use Test\TestCase;
+
+class ICAPClientTest extends TestCase {
+	public function testConnect_ShouldThrowRuntimeException() {
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('Cannot connect to "tcp://nothinghere:8080": php_network_getaddresses: getaddrinfo for nothinghere failed: Name or service not known (code 0)');
+		$icapClient = new ICAPClient("nothinghere", 8080, 2);
+		$icapClient->respmod("myservice",  [], [], []);
+	}
+}

--- a/tests/ICAP/ICAPClientTest.php
+++ b/tests/ICAP/ICAPClientTest.php
@@ -14,8 +14,8 @@ use Test\TestCase;
 class ICAPClientTest extends TestCase {
 	public function testConnect_ShouldThrowRuntimeException() {
 		$this->expectException(\RuntimeException::class);
-		$this->expectExceptionMessage('Cannot connect to "tcp://nothinghere:8080": php_network_getaddresses: getaddrinfo for nothinghere failed: Name or service not known (code 0)');
+		$this->expectExceptionMessageMatches('/Cannot connect to "tcp\:\/\/nothinghere\:8080"\: .*/');
 		$icapClient = new ICAPClient("nothinghere", 8080, 2);
-		$icapClient->respmod("myservice",  [], [], []);
+		$icapClient->respmod("myservice", [], [], []);
 	}
 }

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -8,7 +8,7 @@
 
 namespace OCA\Files_Antivirus\Tests;
 
-use \OCA\Files_Antivirus\Db\RuleMapper;
+use OCA\Files_Antivirus\Db\RuleMapper;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -289,6 +289,10 @@ namespace OC\Files\Storage\Wrapper{
 		public function getWatcher() {
 			throw new \Exception('stub');
 		}
+
+		public function setOwner(?string $user): void {
+			throw new \Exception('stub');
+		}
 	}
 
 	class Jail extends Wrapper {


### PR DESCRIPTION
this is in response [to this thread](https://help.nextcloud.com/t/error-when-try-a-save-profile-settings-when-changing-settings-for-antivirus-when-using-an-icap-profile/199787/2).

Previous Behaviour: When the client was not able to connect the stream was not set, resulting in an error when calling the socket_set_timeout function.

Changed Behaviour: When the is not able to connect the RuntimeException will be thrown with proper ErrorMessage and ErrorCode.