### PR TITLE
chore: fix compatibility of AvirWrapper::file_put_contents()

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -141,7 +141,7 @@ class AvirWrapper extends Wrapper {
 	 * @return false|float|int
 	 * @throws InvalidContentException
 	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		if ($this->shouldWrap($path)) {
 			$scanner = $this->scannerFactory->getScanner($this->mountPoint . $path);
 			$scanner->initScanner();


### PR DESCRIPTION
```
{
  "reqId": "Zxj0ppQQu9QyWi0XMNJWBwAAAAo",
  "level": 3,
  "time": "2024-10-23T13:05:42+00:00",
  "remoteAddr": "100.86.114.111",
  "user": "admin",
  "app": "PHP",
  "method": "POST",
  "url": "/master/index.php/login",
  "message": "Declaration of OCA\\Files_Antivirus\\AvirWrapper::file_put_contents($path, $data) must be compatible with OC\\Files\\Storage\\Wrapper\\Wrapper::file_put_contents(string $path, mixed $data): int|float|false at /home/richard/src/nextcloud/master/dev_apps/files_antivirus/lib/AvirWrapper.php#144",
  "userAgent": "[REDACTED]",
  "version": "31.0.0.3",
  "data": {
    "app": "PHP"
  }
}
```