### PR TITLE
fix: don't report unscanned files which will never be scanned

### DIFF
--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -210,10 +210,7 @@ class BackgroundScanner extends TimedJob {
 			->leftJoin('fc', 'files_antivirus', 'fa', $query->expr()->eq('fc.fileid', 'fa.fileid'))
 			->where($query->expr()->isNull('fa.fileid'))
 			->andWhere($query->expr()->neq('mimetype', $query->createNamedParameter($dirMimeTypeId)))
-			->andWhere($query->expr()->orX(
-				$query->expr()->like('path', $query->createNamedParameter('files/%')),
-				$query->expr()->notLike('s.id', $query->createNamedParameter('home::%'))
-			))
+			->andWhere($query->expr()->like('path', $query->createNamedParameter('files/%')))
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 


### PR DESCRIPTION
The `files_antivirus:status` command reports files outside of user homes that will never be scanned. This might be confusing as it can report up to 1000 unscanned files and that number will never go down.