### PR TITLE
Make notice instead of error message

### DIFF
--- a/lib/Item.php
+++ b/lib/Item.php
@@ -127,13 +127,12 @@ class Item {
 
 	/**
 	 * 	 * Action to take if this item status is unclear
-	 * 	 *
+	 * 	 * (often due to exceeded size limit)
 	 *
 	 * @param Status $status
 	 */
 	public function processUnchecked(Status $status): void {
-		//TODO: Show warning to the user: The file can not be checked
-		$this->logError('Not Checked. ' . $status->getDetails());
+		$this->logNotice('File is not checked: ' . $status->getDetails());
 	}
 
 	/**
@@ -243,6 +242,13 @@ class Item {
 		$this->logger->debug($message . $this->generateExtraInfo(), ['app' => 'files_antivirus']);
 	}
 
+	/**
+	 * @param string $message
+	 */
+	public function logNotice($message): void {
+		$this->logger->notice($message . $this->generateExtraInfo(), ['app' => 'files_antivirus']);
+	}
+	
 	/**
 	 * @param string $message
 	 */


### PR DESCRIPTION
- Change error messages like "No matching rule for response [INSTREAM size limit exceeded. ERROR]." a notice, rather than an error message.
- Fix error pollution

Fixes: https://github.com/nextcloud/files_antivirus/issues/397