### PR TITLE
fix: clean up obsolete etag column

### DIFF
--- a/lib/Migration/Version60100Date20250424072838.php
+++ b/lib/Migration/Version60100Date20250424072838.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version60100Date20250424072838 extends SimpleMigrationStep {
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	public function changeSchema(
+		IOutput $output,
+		Closure $schemaClosure,
+		array $options,
+	): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$filesAntivirusTable = $schema->getTable('files_antivirus');
+		if ($filesAntivirusTable->hasColumn('etag')) {
+			$filesAntivirusTable->dropColumn('etag');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Fix #222 

This column is created by the files_antivirus app of ownCloud but is not used in Nextcloud's version of the app.