### PR TITLE
fix: exclude groupfolder trash and version files

### DIFF
--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -220,6 +220,8 @@ class BackgroundScanner extends TimedJob {
 				$query->expr()->notLike('s.id', $query->createNamedParameter('home::%'))
 			))
 			->andWhere($query->expr()->notLike('fc.path', $query->createNamedParameter("appdata_$instanceId/%")))
+			->andWhere($query->expr()->notLike('fc.path', $query->createNamedParameter("\_\_groupfolders/versions/%")))
+			->andWhere($query->expr()->notLike('fc.path', $query->createNamedParameter("\_\_groupfolders/trash/%")))
 			->andWhere($this->getSizeLimitExpression($query))
 			->setMaxResults($this->getBatchSize() * 10);
 


### PR DESCRIPTION
Ref #437

Nodes for groupfolder version files and trash files can not be retrieved. Thus, it will not be scanned: https://github.com/nextcloud/files_antivirus/blob/2c5347a782897f87f724356f10fbe00f760c824c/lib/BackgroundJob/BackgroundScanner.php#L145-L153

However, they are still reported by the `files_antivirus:status` command. They should be excluded when looking for unscanned files.

Here are some examples:

|fileid|path                                                             |
|------|-----------------------------------------------------------------|
|13.781|__groupfolders/trash/8/2025-04-29_14-29-31_swappy.png.d1746001330|
|13.794|__groupfolders/versions/8/13781/1745934694                       |
|13.804|__groupfolders/versions/8/13781/1745934689                       |
|13.825|__groupfolders/versions/8/13815/1745999693                       |
|13.835|__groupfolders/versions/8/13815/1745934689                       |