### PR TITLE
fix: handle ClamAV not responding properly

### DIFF
--- a/lib/Scanner/ExternalClam.php
+++ b/lib/Scanner/ExternalClam.php
@@ -70,6 +70,9 @@ class ExternalClam extends ScannerBase {
 		if ($info['timed_out']) {
 			$this->status->setNumericStatus(Status::SCANRESULT_UNCHECKED);
 			$this->status->setDetails('Socket timed out while scanning');
+		} elseif ($response === false) {
+			$this->status->setNumericStatus(Status::SCANRESULT_UNCHECKED);
+			$this->status->setDetails('Failed to read response from ClamAV');
 		} else {
 			$this->status->parseResponse($response);
 		}


### PR DESCRIPTION
Fix #387

When ClamAV does not manage to send a response (because it crashes etc.), the response will be `false` instead of a string. We should handle this case more gracefully.