### PR TITLE
fix: wrap encrypted group folders

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,6 +17,7 @@ use OCA\Files_Antivirus\Scanner\ICAP;
 use OCA\Files_Antivirus\Scanner\LocalClam;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCA\Files_Antivirus\StatusFactory;
+use OCA\GroupFolders\Mount\GroupFolderEncryptionJail;
 use OCP\Activity\IManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\App;
@@ -88,8 +89,10 @@ class Application extends App implements IBootstrap {
 		Filesystem::addStorageWrapper(
 			'oc_avir',
 			function (string $mountPoint, IStorage $storage) {
-				if ($storage->instanceOfStorage(Jail::class)) {
-					// No reason to wrap jails again
+				if ($storage->instanceOfStorage(Jail::class)
+					&& !$storage->instanceOfStorage(GroupFolderEncryptionJail::class)) {
+					// No reason to wrap jails again.
+					// Make an exception for encrypted group folders.
 					return $storage;
 				}
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -28,6 +28,7 @@
 			<errorLevel type="suppress">
 				<referencedClass name="OC" />
 				<referencedClass name="OCA\Files_External\Service\UserGlobalStoragesService" />
+				<referencedClass name="OCA\GroupFolders\Mount\GroupFolderEncryptionJail" />
 				<referencedClass name="OC\Core\Command\Base" />
 				<referencedClass name="OC\Files\Cache\Wrapper\CacheWrapper" />
 				<referencedClass name="OC\Files\Filesystem" />


### PR DESCRIPTION
## How to test?

1. Set up a group folder.
2. Enable server side encryption.
3. Enable encryption for group folders: `occ config:app:set groupfolders enable_encryption --value="true"`
4. Upload an eicar test file to the group folder.

**Before:** The virus is not detected and the upload is not blocked.
**After:** The virus is detected and the upload is blocked.

Note: The background scan via occ always detects the virus correctly (before and after).

## My observations

The app seems to wrap the incorrect storage and sends the encrypted file to the external antivirus scanner. With my changes it wraps the correct storage and sends the unencrypted, plain file to the scanner.