### PR TITLE
fix: scan assembled files instead of individual parts

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -142,6 +142,7 @@ class Application extends App implements IBootstrap {
 					'block_unscannable' => $appConfig->getAvBlockUnscannable(),
 					'userManager' => $userManager,
 					'block_unreachable' => $appConfig->getAvBlockUnreachable(),
+					'chunk_size' => $appConfig->getAvChunkSize(),
 				]);
 			},
 			1

--- a/lib/Scanner/ICAP.php
+++ b/lib/Scanner/ICAP.php
@@ -71,9 +71,6 @@ class ICAP extends ScannerBase {
 		}
 
 		$path = '/' . trim($this->path, '/');
-		if (str_contains($path, '.ocTransferId') && str_ends_with($path, '.part')) {
-			[$path] = explode('.ocTransferId', $path, 2);
-		}
 		$remote = $this->request ? $this->request->getRemoteAddress() : null;
 		$encodedPath = implode('/', array_map('rawurlencode', explode('/', $path)));
 


### PR DESCRIPTION
Wait until the whole uploaded file is assembled and scan it it in bulk instead of scanning the individual part files during upload.