### PR TITLE
fix: handle unscannable files in files_put_contents() as well

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -155,6 +155,9 @@ class AvirWrapper extends Wrapper {
 			if ($status->getNumericStatus() === Status::SCANRESULT_INFECTED) {
 				$this->handleInfected($path, $status);
 			}
+			if ($this->blockUnscannable && $status->getNumericStatus() === Status::SCANRESULT_UNSCANNABLE) {
+				$this->handleInfected($path, $status);
+			}
 		}
 
 		return parent::file_put_contents($path, $data);


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/files_antivirus/pull/378

The logic was not applied to the wrapper of `files_put_contents()`.