### PR TITLE
fix: extract actual path when scanning ocTransferId files

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use OCP\ICertificateManager;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
@@ -142,6 +143,7 @@ class Application extends App implements IBootstrap {
 					'block_unscannable' => $appConfig->getAvBlockUnscannable(),
 					'userManager' => $userManager,
 					'block_unreachable' => $appConfig->getAvBlockUnreachable(),
+					'request' => $container->get(IRequest::class),
 				]);
 			},
 			1

--- a/lib/Scanner/ICAP.php
+++ b/lib/Scanner/ICAP.php
@@ -71,9 +71,6 @@ class ICAP extends ScannerBase {
 		}
 
 		$path = '/' . trim($this->path, '/');
-		if (str_contains($path, '.ocTransferId') && str_ends_with($path, '.part')) {
-			[$path] = explode('.ocTransferId', $path, 2);
-		}
 		$remote = $this->request ? $this->request->getRemoteAddress() : null;
 		$encodedPath = implode('/', array_map('rawurlencode', explode('/', $path)));
 

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -15,6 +15,7 @@ use OCA\Files_Antivirus\Scanner\IScanner;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCA\Files_Antivirus\StatusFactory;
 use OCP\Activity\IManager;
+use OCP\IRequest;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -80,7 +81,8 @@ class AvirWrapperTest extends TestBase {
 			'mount_point' => '/' . self::UID . '/files/',
 			'block_unscannable' => false,
 			'userManager' => $this->createMock(IUserManager::class),
-			'block_unreachable' => 'yes'
+			'block_unreachable' => 'yes',
+			'request' => $this->createMock(IRequest::class),
 		]);
 
 		$this->config->expects($this->any())
@@ -144,6 +146,7 @@ class AvirWrapperTest extends TestBase {
 			'block_unscannable' => false,
 			'userManager' => $this->createMock(IUserManager::class),
 			'block_unreachable' => 'no',
+			'request' => $this->createMock(IRequest::class),
 		]);
 
 		$scanner = $this->createMock(IScanner::class);
@@ -180,7 +183,7 @@ class AvirWrapperTest extends TestBase {
 			->method('error')
 			->with($this->stringContains('Simulated failure'));
 
-		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', ]) extends \OCA\Files_Antivirus\AvirWrapper {
+		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class) ]) extends \OCA\Files_Antivirus\AvirWrapper {
 			public bool $connectionErrorCalled = false;
 			protected function handleConnectionError(string $path): void {
 				$this->connectionErrorCalled = true;


### PR DESCRIPTION
Alternative to #480 

Try to extract the actual path of a file based on `IRequest::getPathInfo()` if a `ocTransferId` file is scanned.