### PR TITLE
feature: added config av_blocklisted_directories and do not scan directory, groupfolder with name in the array

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -19,7 +19,7 @@ use OCP\IConfig;
  * @method ?string getAvPath()
  * @method ?string getAvInfectedAction()
  * @method ?string getAvBlockUnreachable()
- * @method ?string getAvDontScanDir()
+ * @method ?string getAvBlocklistedDirectories()
  * @method ?string getAvStreamMaxLength()
  * @method string getAvIcapMode()
  * @method ?string getAvIcapRequestService()
@@ -37,7 +37,7 @@ use OCP\IConfig;
  * @method null setAvPath(string $avPath)
  * @method null setAvInfectedAction(string $avInfectedAction)
  * @method null setAvBlockUnreachable(string $avBlockUnreachable)
- * @method null setAvDontScanDir(string $avDontScanDir)
+ * @method null setAvBlocklistedDirectories(string $avBlocklistedDirectories)
  * @method null setAvIcapScanBackground(string $scanBackground)
  * @method null setAvIcapMode(string $mode)
  * @method null setAvIcapRequestService($reqService)
@@ -71,7 +71,7 @@ class AppConfig {
 		'av_icap_connect_timeout' => '5',
 		'av_scan_first_bytes' => -1,
 		'av_block_unscannable' => false,
-		'av_dont_scan_dir' => '',
+		'av_blocklisted_directories' => '[]',
 	];
 
 	/**
@@ -107,6 +107,11 @@ class AppConfig {
 
 	public function setAvBlockUnscannable(bool $block): void {
 		$this->setAppValue('av_block_unscannable', $block ? '1' : '0');
+	}
+
+	public function getAvBlocklistedDirectories(): array {
+		$blockListed = $this->getAppValue('av_blocklisted_directories');
+		return json_decode($blockListed);
 	}
 
 	/**

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -143,7 +143,7 @@ class Application extends App implements IBootstrap {
 					'block_unreachable' => $appConfig->getAvBlockUnreachable(),
 					'request' => $container->get(IRequest::class),
 					'groupFoldersEnabled' => $appManager->isEnabledForUser('groupfolders'),
-					'dont_scan_directory' => $appConfig->getAvDontScanDir(),
+					'blockListedDirectories' => $appConfig->getAvBlocklistedDirectories(),
 				]);
 			},
 			1,

--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -40,7 +40,7 @@ class AvirWrapper extends Wrapper {
 	private IUserManager $userManager;
 	private string $blockUnReachable = 'yes';
 	private IRequest $request;
-	private string $dontScanDir = '';
+	private array $blockListedDirectories = [];
 
 	/**
 	 * @param array $parameters
@@ -59,7 +59,7 @@ class AvirWrapper extends Wrapper {
 		$this->blockUnReachable = $parameters['block_unreachable'];
 		$this->request = $parameters['request'];
 		$this->groupFoldersEnabled = $parameters['groupFoldersEnabled'];
-		$this->dontScanDir = $parameters['dont_scan_directory'];
+		$this->blockListedDirectories = $parameters['blockListedDirectories'];
 
 		/** @var IEventDispatcher $eventDispatcher */
 		$eventDispatcher = $parameters['eventDispatcher'];
@@ -96,20 +96,23 @@ class AvirWrapper extends Wrapper {
 	}
 
 	private function shouldWrap(string $path): bool {
-		if ($this->dontScanDir != '') {
-			if (str_contains($this->mountPoint . $path, "/".$this->dontScanDir."/")) {
-				//don't scan directory or new group folder named dontScanDir
+		if ($this->blockListedDirectories) {
+			$relativePathParts = explode('/', $this->mountPoint . $path);
+			if (array_intersect($relativePathParts, $this->blockListedDirectories)) {
+				// Don't scan directory or new group folders in the block list
 				return false;
 			}
 			if ($this->groupFoldersEnabled) {
 				/** @var FolderManager $folderManager */
-				$folderManager = \OC::$server->query(FolderManager::class);
+				$folderManager = \OCP\Server::get(FolderManager::class);
 
 				if (preg_match('#^/?__groupfolders/(\d+)#', $path, $matches)) {
 					$folderId = (int)$matches[1];
 					$folder = $folderManager->getFolder($folderId);
-					if (($folderId == $folder->id) && ($folder->mountPoint === $this->dontScanDir)) {
-						//don't scan old group folder named dontScanDir
+
+					if ($folderId === $folder->id
+						&& in_array($folder->mountPoint, $this->blockListedDirectories)) {
+						// Don't scan old group folders in the block list
 						return false;
 					}
 				}

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -79,7 +79,7 @@ class AvirWrapperTest extends TestBase {
 			'eventDispatcher' => $this->createMock(EventDispatcherInterface::class),
 			'trashEnabled' => true,
 			'groupFoldersEnabled' => false,
-			'dont_scan_directory' => 'escape-scan',
+			'blockListedDirectories' => ['escape-scan', 'dont-scan'],
 			'mount_point' => '/' . self::UID . '/files/',
 			'block_unscannable' => false,
 			'userManager' => $this->createMock(IUserManager::class),
@@ -130,6 +130,9 @@ class AvirWrapperTest extends TestBase {
 			['/files_external/rootcerts.crt.tmp.0123456789', false],
 			['/root_file', false],
 			['files/escape-scan/my_file_2', false],
+			['files/dont-scan/my_file_2', false],
+			['files/dont-scan/scan/my_file_2', false],
+			['files/scan/my_file_2', true],
 			['files/scanforvirus/my_file_2', true],
 		];
 	}
@@ -147,7 +150,7 @@ class AvirWrapperTest extends TestBase {
 			'eventDispatcher' => $this->createMock(EventDispatcherInterface::class),
 			'trashEnabled' => true,
 			'groupFoldersEnabled' => false,
-			'dont_scan_directory' => 'escape-scan',
+			'blockListedDirectories' => ['escape-scan', 'dont-scan'],
 			'mount_point' => null,
 			'block_unscannable' => false,
 			'userManager' => $this->createMock(IUserManager::class),
@@ -189,7 +192,7 @@ class AvirWrapperTest extends TestBase {
 			->method('error')
 			->with($this->stringContains('Simulated failure'));
 
-		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class), 'dont_scan_directory' => 'escape-scan', 'groupFoldersEnabled' => false, ]) extends \OCA\Files_Antivirus\AvirWrapper {
+		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class), 'blockListedDirectories' => ['escape-scan'], 'groupFoldersEnabled' => false, ]) extends \OCA\Files_Antivirus\AvirWrapper {
 			public bool $connectionErrorCalled = false;
 			protected function handleConnectionError(string $path): void {
 				$this->connectionErrorCalled = true;


### PR DESCRIPTION
pre-requisite: set 

`occ config:app:set files_antivirus av_blocklisted_directories --value='["dont-scan", "donotscan", "second-dir"]'`

once done scanning will be disabled for the directories and group folder with name mentioned in the above config