### PR TITLE
fix: only skip jails if they already have an av wrapper

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2015-2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Files_Antivirus\AppInfo;
 
 use OC\Files\Filesystem;
@@ -91,22 +92,19 @@ class Application extends App implements IBootstrap {
 	}
 
 	/**
-	 * 	 * Add wrapper for local storages
+	 * Add wrapper for local storages
 	 */
 	public function setupWrapper(): void {
 		if ($this->groupFolderEncryptionEnabled === null && $this->appConfig) {
-			$this->groupFolderEncryptionEnabled = $this->appConfig->getValueString(
-				'groupfolders',
-				'enable_encryption',
-				'false',
-			) === 'true';
+			$this->groupFolderEncryptionEnabled = $this->appConfig->getValueBool('groupfolders', 'enable_encryption');
 		}
 
 		Filesystem::addStorageWrapper(
 			'oc_avir',
 			function (string $mountPoint, IStorage $storage) {
-				if ($storage->instanceOfStorage(Jail::class)
-					&& (
+				if (
+					$storage->instanceOfStorage(AvirWrapper::class) &&
+					$storage->instanceOfStorage(Jail::class) && (
 						$storage->instanceOfStorage(ISharedStorage::class)
 						|| !(
 							$this->groupFolderEncryptionEnabled
@@ -146,7 +144,7 @@ class Application extends App implements IBootstrap {
 					'request' => $container->get(IRequest::class),
 				]);
 			},
-			1
+			1,
 		);
 	}
 }


### PR DESCRIPTION
This is needed to make it work with groupfolders for 32. As that uses `Jail`s on storages that haven't been wrapped yet.