### PR TITLE
chore(release): v5.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.6.6] - 2025-09-22
+## Fixed
+* Extract actual path when scanning ocTransferId files
+* Use given limit when retrieving unscanned files
+
 ## [5.6.4] - 2025-08-04
 ## Fixed
 * Faster loading for SharedStorage

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 This application inspects files that are uploaded to Nextcloud for viruses before they are written to the Nextcloud storage. If a file is identified as a virus, it is either logged or not uploaded to the server. The application relies on the underlying ClamAV virus scanning engine, which the admin points Nextcloud to when configuring the application. Alternatively, a Kaspersky Scan Engine can be configured, which has to run on a separate server.
 For this app to be effective, the ClamAV virus definitions should be kept up to date. Also note that enabling this app will impact system performance as additional processing is required for every upload. More information is available in the Antivirus documentation.
 	]]></description>
-	<version>5.6.5</version>
+	<version>5.6.6</version>
 	<licence>agpl</licence>
 
 	<author>Manuel Delgado</author>


### PR DESCRIPTION
# Changelog

## [6.0.5] - 2025-09-22
## Fixed
* Extract actual path when scanning ocTransferId files
* Use given limit when retrieving unscanned files