### PR TITLE
fix: don't try to scan content twice if stream is seeked backwards

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -99,10 +99,16 @@ class AvirWrapper extends Wrapper {
 		try {
 			$scanner = $this->scannerFactory->getScanner($this->mountPoint ? $this->mountPoint . $path : null);
 			$scanner->initScanner();
+			$amountRead = 0;
 			return CallbackReadDataWrapper::wrap(
 				$stream,
-				function ($count, $data) use ($scanner) {
-					$scanner->onAsyncData($data);
+				function ($count, $data) use ($scanner, $stream, &$amountRead) {
+					$pos = ftell($stream);
+					// don't scan twice when the stream is seeked backwards during reading
+					if ($pos > $amountRead) {
+						$scanner->onAsyncData($data);
+						$amountRead = $pos;
+					}
 				},
 				function ($data) use ($scanner) {
 					$scanner->onAsyncData($data);


### PR DESCRIPTION
During s3 uploads, the aws sdk performs a file read (to calculate the hash), then rewinds the stream before reading again.

This would cause the av wrapper to try to scan the contents twice, causing unnecessary overhead and issues with certain setups.

To test:

- Setup an NC instance with s3 primary storage
- Setup clamav with a unix socket and configure files_antivirus to use it
- Try to upload a large a large enough pdf[1]

[1]: Not sure about the requirements, some pdf files seem to trigger it while some don't.