### PR TITLE
fix(wrapper): Ensure node is not null when checking if it is E2EE

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -136,7 +136,7 @@ class AvirWrapper extends Wrapper {
 			$owner = $this->storage->getOwner($path);
 			$userFolder = $rootFolder->getUserFolder($owner);
 			$node = $userFolder->getFirstNodeById($parentId);
-			if ($node->isEncrypted()) {
+			if ($node !== null && $node->isEncrypted()) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Follow-up of https://github.com/nextcloud/files_antivirus/pull/526