### PR TITLE
fix(scanner): Make background scan batch size configurable

### DIFF
--- a/lib/AppInfo/ConfigLexicon.php
+++ b/lib/AppInfo/ConfigLexicon.php
@@ -40,6 +40,8 @@ class ConfigLexicon implements ILexicon {
 	public const AV_BLOCKLISTED_DIRECTORIES = 'av_blocklisted_directories';
 	public const AV_BACKGROUND_SCAN = 'av_background_scan';
 	public const AV_RESCAN_DAYS = 'av_rescan_days';
+	public const AV_SCAN_BATCH_SIZE = 'av_scan_batch_size';
+	public const AV_SCAN_BATCH_SIZE_CLI = 'av_scan_batch_size_cli';
 
 	#[Override]
 	public function getStrictness(): Strictness {
@@ -114,6 +116,18 @@ class ConfigLexicon implements ILexicon {
 				type: ValueType::BOOL,
 				defaultRaw: true,
 				definition: 'Whether to scan files in background after upload or scan them during upload.',
+			),
+			new Entry(
+				key: self::AV_SCAN_BATCH_SIZE,
+				type: ValueType::INT,
+				defaultRaw: 10,
+				definition: 'Number of files processed by the background scanner per run when triggered via the cron. Lower this to throttle ClamAV load (e.g. while clearing a backlog after upgrades).',
+			),
+			new Entry(
+				key: self::AV_SCAN_BATCH_SIZE_CLI,
+				type: ValueType::INT,
+				defaultRaw: 100,
+				definition: 'Number of files processed by the background scanner per run when triggered via the CLI. Lower this to throttle ClamAV load (e.g. while clearing a backlog after upgrades).',
 			),
 			new Entry(
 				key: self::AV_STREAM_MAX_LENGTH,

--- a/lib/AppInfo/ConfigLexicon.php
+++ b/lib/AppInfo/ConfigLexicon.php
@@ -42,6 +42,7 @@ class ConfigLexicon implements ILexicon {
 	public const AV_RESCAN_DAYS = 'av_rescan_days';
 	public const AV_SCAN_BATCH_SIZE = 'av_scan_batch_size';
 	public const AV_SCAN_BATCH_SIZE_CLI = 'av_scan_batch_size_cli';
+	public const AV_SCAN_INTERVAL = 'av_scan_interval';
 
 	#[Override]
 	public function getStrictness(): Strictness {
@@ -128,6 +129,12 @@ class ConfigLexicon implements ILexicon {
 				type: ValueType::INT,
 				defaultRaw: 100,
 				definition: 'Number of files processed by the background scanner per run when triggered via the CLI. Lower this to throttle ClamAV load (e.g. while clearing a backlog after upgrades).',
+			),
+			new Entry(
+				key: self::AV_SCAN_INTERVAL,
+				type: ValueType::INT,
+				defaultRaw: 900,
+				definition: 'Minimum number of seconds between background scanner runs. The effective interval is also bounded by the cron mechanism (ajax/webcron/system cron).',
 			),
 			new Entry(
 				key: self::AV_STREAM_MAX_LENGTH,

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -14,6 +14,7 @@ use OCA\Files_Antivirus\ItemFactory;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -44,8 +45,9 @@ class BackgroundScanner extends TimedJob {
 	) {
 		parent::__construct($timeFactory);
 
-		// Run once per 15 minutes
-		$this->setInterval(60 * 15);
+		$this->setInterval($this->appConfig->getAppValueInt(ConfigLexicon::AV_SCAN_INTERVAL));
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setAllowParallelRuns(false);
 	}
 
 	/**
@@ -157,10 +159,6 @@ class BackgroundScanner extends TimedJob {
 			$batchSize = $this->appConfig->getAppValueInt(ConfigLexicon::AV_SCAN_BATCH_SIZE_CLI);
 		} else {
 			$batchSize = $this->appConfig->getAppValueInt(ConfigLexicon::AV_SCAN_BATCH_SIZE);
-		}
-
-		if ($batchSize < 1) {
-			$batchSize = $this->isCLI ? 100 : 10;
 		}
 
 		$this->logger->debug('Batch size is: ' . $batchSize);

--- a/lib/BackgroundJob/BackgroundScanner.php
+++ b/lib/BackgroundJob/BackgroundScanner.php
@@ -153,9 +153,14 @@ class BackgroundScanner extends TimedJob {
 	}
 
 	public function getBatchSize(): int {
-		$batchSize = 10;
 		if ($this->isCLI) {
-			$batchSize = 100;
+			$batchSize = $this->appConfig->getAppValueInt(ConfigLexicon::AV_SCAN_BATCH_SIZE_CLI);
+		} else {
+			$batchSize = $this->appConfig->getAppValueInt(ConfigLexicon::AV_SCAN_BATCH_SIZE);
+		}
+
+		if ($batchSize < 1) {
+			$batchSize = $this->isCLI ? 100 : 10;
 		}
 
 		$this->logger->debug('Batch size is: ' . $batchSize);

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -76,6 +76,12 @@ abstract class TestBase extends TestCase {
 				return false;
 			case ConfigLexicon::AV_RESCAN_DAYS:
 				return 28;
+			case ConfigLexicon::AV_SCAN_INTERVAL:
+				return 900;
+			case ConfigLexicon::AV_SCAN_BATCH_SIZE:
+				return 10;
+			case ConfigLexicon::AV_SCAN_BATCH_SIZE_CLI:
+				return 100;
 			default:
 				throw new \RuntimeException("Unexpected config key: $configKey");
 		}


### PR DESCRIPTION
After v6.1.0 started wrapping jail-based storages (groupfolders, shares), large instances face a sustained ClamAV CPU spike while the background scanner clears the resulting backlog at the hardcoded batch size of 10 (web) / 100 (CLI) per run.

Introduce two app config keys, av_scan_batch_size and av_scan_batch_size_cli, so admins can throttle scanner load during the migration window and restore defaults afterwards. The previous hardcoded values remain as fallbacks.

Fixes #541