### PR TITLE
fix: Set status infected when http prefix is missign

### DIFF
--- a/lib/Scanner/ICAP.php
+++ b/lib/Scanner/ICAP.php
@@ -130,7 +130,7 @@ class ICAP extends ScannerBase {
 
 			// kaspersky(pre 2020 product editions) and McAfee handling
 			$respHeader = $response->getResponseHeaders()['HTTP_STATUS'] ?? '';
-			if (\strpos($respHeader, '403 Forbidden') || \strpos($respHeader, '403 VirusFound')) {
+			if (\str_contains($respHeader, '403 Forbidden') || \str_contains($respHeader, '403 VirusFound')) {
 				$this->status->setNumericStatus(Status::SCANRESULT_INFECTED);
 			}
 		} elseif ($code === 202) {


### PR DESCRIPTION
A security researcher reported that the current implementation would not set the infected status if the line starts with `403 Forbidden`. 

ICAP encapsulated seems to wrap http messages, and hence that case is rather unlikely because the status line should always start with HTTPxx as show in our stubs (e.g. https://github.com/nextcloud/files_antivirus/blob/16752556d2298d6721c812760319310061b723d6/tests/data/icap/403-response.txt#L9).

I assume the intention was "if contains 403, then infected", and hence we want to use str_contains or strpos !== false. 