### PR TITLE
fix: mark files as scanned on upload

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,6 +9,7 @@
 namespace OCA\Files_Antivirus\AppInfo;
 
 use OCA\Files_Antivirus\Listener\FilesystemSetupListener;
+use OCA\Files_Antivirus\Listener\NodeWrittenListener;
 use OCA\Files_Antivirus\Scanner\ExternalClam;
 use OCA\Files_Antivirus\Scanner\ExternalKaspersky;
 use OCA\Files_Antivirus\Scanner\ICAP;
@@ -20,6 +21,7 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\Files\Events\BeforeFileSystemSetupEvent;
+use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\ICertificateManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -70,6 +72,7 @@ class Application extends App implements IBootstrap {
 		}, false);
 
 		$context->registerEventListener(BeforeFileSystemSetupEvent::class, FilesystemSetupListener::class);
+		$context->registerEventListener(NodeWrittenEvent::class, NodeWrittenListener::class);
 	}
 
 	#[\Override]

--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -49,6 +49,7 @@ class AvirWrapper extends Wrapper {
 	private bool $blockUnReachable;
 	private IRequest $request;
 	private array $blockListedDirectories;
+	private ScannedPathsRegistry $scannedPathsRegistry;
 
 	/**
 	 * @psalm-suppress MoreSpecificImplementedParamType
@@ -68,7 +69,8 @@ class AvirWrapper extends Wrapper {
 	 *     request: IRequest,
 	 *     groupFoldersEnabled: bool,
 	 *     e2eeEnabled: bool,
-	 *     blockListedDirectories: array
+	 *     blockListedDirectories: array,
+	 *     scannedPathsRegistry: ScannedPathsRegistry,
 	 * } $parameters
 	 */
 	public function __construct($parameters) {
@@ -87,6 +89,7 @@ class AvirWrapper extends Wrapper {
 		$this->groupFoldersEnabled = $parameters['groupFoldersEnabled'];
 		$this->e2eeEnabled = $parameters['e2eeEnabled'];
 		$this->blockListedDirectories = $parameters['blockListedDirectories'];
+		$this->scannedPathsRegistry = $parameters['scannedPathsRegistry'];
 
 		/** @var IEventDispatcher $eventDispatcher */
 		$eventDispatcher = $parameters['eventDispatcher'];
@@ -193,6 +196,36 @@ class AvirWrapper extends Wrapper {
 	}
 
 	/**
+	 * Build the registry key for a path: the absolute path the committed file will have,
+	 * matching Node::getPath() used in NodeWrittenListener.
+	 *
+	 * For hashed .part files (e.g. abc123.ocTransferId1234.part) the real filename is
+	 * not recoverable from the storage path — we must read it from the DAV request URI,
+	 * the same technique used by getPathForScanner(). The DAV URI has the form
+	 * /dav/files/{username}/{relative_path}, which maps to /{username}/files/{relative_path}
+	 * in Node::getPath().
+	 */
+	private function getRegistryPath(string $path): string {
+		if (preg_match('/\.ocTransferId\d+\.part$/i', $path)) {
+			$davFilesPrefix = '/dav/files';
+			$pathInfo = $this->request->getPathInfo();
+			if (str_starts_with($pathInfo, $davFilesPrefix)) {
+				$afterPrefix = substr($pathInfo, strlen($davFilesPrefix)); // /{username}/{relative}
+				$secondSlash = strpos($afterPrefix, '/', 1);
+				if ($secondSlash !== false) {
+					// Insert /files between the username segment and the rest of the path
+					return substr($afterPrefix, 0, $secondSlash) . '/files' . substr($afterPrefix, $secondSlash);
+				}
+			}
+		}
+
+		// Non-hashed paths (file_put_contents, writeStream, or non-DAV uploads):
+		// mount point + storage-relative path is already the correct absolute path.
+		$normalizedPath = preg_replace('/\.ocTransferId\d+\.part$/i', '', $path) ?? $path;
+		return rtrim($this->mountPoint ?? '', '/') . '/' . ltrim($normalizedPath, '/');
+	}
+
+	/**
 	 * Try to extract actual path for .ocTransferId.part files (because the name is hashed).
 	 */
 	private function getPathForScanner(string $path): ?string {
@@ -239,6 +272,16 @@ class AvirWrapper extends Wrapper {
 				if ($this->blockUnReachable && $status->getNumericStatus() === Status::SCANRESULT_UNCHECKED) {
 					$this->handleConnectionError($path, true);
 				}
+				// Register result only when the file is accepted (not blocked).
+				// UNCHECKED without block_unreachable means AV was unreachable — do NOT
+				// mark as scanned so the background scanner retries it.
+				if (
+					$status->getNumericStatus() === Status::SCANRESULT_CLEAN
+					|| ($status->getNumericStatus() === Status::SCANRESULT_UNSCANNABLE && !$this->blockUnscannable)
+				) {
+					$registryPath = $this->getRegistryPath($path);
+					$this->scannedPathsRegistry->registerResult($registryPath, $status->getNumericStatus());
+				}
 			}
 		);
 	}
@@ -277,6 +320,13 @@ class AvirWrapper extends Wrapper {
 			}
 			if ($this->blockUnReachable && $status->getNumericStatus() === Status::SCANRESULT_UNCHECKED) {
 				$this->handleConnectionError($path);
+			}
+			// Register result only when the file is accepted (not blocked).
+			if (
+				$status->getNumericStatus() === Status::SCANRESULT_CLEAN
+				|| ($status->getNumericStatus() === Status::SCANRESULT_UNSCANNABLE && !$this->blockUnscannable)
+			) {
+				$this->scannedPathsRegistry->registerResult($this->getRegistryPath($path), $status->getNumericStatus());
 			}
 		}
 

--- a/lib/Listener/FilesystemSetupListener.php
+++ b/lib/Listener/FilesystemSetupListener.php
@@ -13,6 +13,7 @@ use OC\Files\Storage\Wrapper\Jail;
 use OCA\Files_Antivirus\AppInfo\Application;
 use OCA\Files_Antivirus\AppInfo\ConfigLexicon;
 use OCA\Files_Antivirus\AvirWrapper;
+use OCA\Files_Antivirus\ScannedPathsRegistry;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCA\GroupFolders\Mount\GroupFolderEncryptionJail;
 use OCP\Activity\IManager as IActivityManager;
@@ -45,6 +46,7 @@ class FilesystemSetupListener implements IEventListener {
 		private readonly IUserManager $userManager,
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly IActivityManager $activityManager,
+		private readonly ScannedPathsRegistry $scannedPathsRegistry,
 		IL10NFactory $l10nFactory,
 	) {
 		$this->l10n = $l10nFactory->get(Application::APP_NAME);
@@ -92,6 +94,7 @@ class FilesystemSetupListener implements IEventListener {
 					'groupFoldersEnabled' => $this->appManager->isEnabledForUser('groupfolders'),
 					'e2eeEnabled' => $this->appManager->isEnabledForUser('end_to_end_encryption'),
 					'blockListedDirectories' => $this->appConfig->getValueArray(Application::APP_NAME, ConfigLexicon::AV_BLOCKLISTED_DIRECTORIES),
+					'scannedPathsRegistry' => $this->scannedPathsRegistry,
 				]);
 			},
 			1,

--- a/lib/Listener/NodeWrittenListener.php
+++ b/lib/Listener/NodeWrittenListener.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Antivirus\Listener;
 
 use OCA\Files_Antivirus\Db\Item;
 use OCA\Files_Antivirus\Db\ItemMapper;
+use OCA\Files_Antivirus\ScannedPathsRegistry;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
@@ -25,6 +26,7 @@ class NodeWrittenListener implements IEventListener {
 		private readonly ItemMapper $itemMapper,
 		private readonly ITimeFactory $timeFactory,
 		private readonly LoggerInterface $logger,
+		private readonly ScannedPathsRegistry $scannedPathsRegistry,
 	) {
 	}
 
@@ -39,7 +41,16 @@ class NodeWrittenListener implements IEventListener {
 			return;
 		}
 
-		// Mark file as scanned after upload completes
+		// Only mark as scanned when AvirWrapper recorded a successful scan result.
+		// If the AV scanner was unreachable and the upload was allowed through
+		// (block_unreachable: false), no result is registered and the file will be
+		// picked up by the background scanner instead.
+		$nodePath = $node->getPath();
+		$registryResult = $this->scannedPathsRegistry->getResult($nodePath);
+		if ($registryResult === null) {
+			return;
+		}
+
 		try {
 			$this->markFileAsScanned($node->getId());
 		} catch (\Exception $e) {

--- a/lib/Listener/NodeWrittenListener.php
+++ b/lib/Listener/NodeWrittenListener.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Listener;
+
+use OCA\Files_Antivirus\Db\Item;
+use OCA\Files_Antivirus\Db\ItemMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\Node\NodeWrittenEvent;
+use OCP\Files\File;
+use Psr\Log\LoggerInterface;
+
+/** @template-implements IEventListener<NodeWrittenEvent> */
+class NodeWrittenListener implements IEventListener {
+	public function __construct(
+		private readonly ItemMapper $itemMapper,
+		private readonly ITimeFactory $timeFactory,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!$event instanceof NodeWrittenEvent) {
+			return;
+		}
+
+		$node = $event->getNode();
+		if (!$node instanceof File) {
+			return;
+		}
+
+		// Mark file as scanned after upload completes
+		try {
+			$this->markFileAsScanned($node->getId());
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to mark uploaded file as scanned: ' . $e->getMessage(), [
+				'app' => 'files_antivirus',
+				'fileId' => $node->getId(),
+				'exception' => $e,
+			]);
+		}
+	}
+
+	private function markFileAsScanned(int $fileId): void {
+		try {
+			$existing = $this->itemMapper->findByFileId($fileId);
+			$this->itemMapper->delete($existing);
+		} catch (DoesNotExistException) {
+			// No existing entry, that's fine
+		}
+
+		$item = new Item();
+		$item->setFileid($fileId);
+		$item->setCheckTime($this->timeFactory->getTime());
+		$this->itemMapper->insert($item);
+	}
+}

--- a/lib/ScannedPathsRegistry.php
+++ b/lib/ScannedPathsRegistry.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus;
+
+/**
+ * Request-scoped registry that tracks which file paths were successfully scanned
+ * during this request. AvirWrapper writes results here; NodeWrittenListener reads
+ * from here to decide whether to persist the "scanned" state to the database.
+ */
+class ScannedPathsRegistry {
+	/** @var array<string, int> normalized path => scan result (Status::SCANRESULT_*) */
+	private array $results = [];
+
+	/**
+	 * Record a scan result for a given absolute filesystem path.
+	 * Only call this when the file is being accepted (i.e. not blocked).
+	 */
+	public function registerResult(string $path, int $status): void {
+		$this->results[$this->normalizePath($path)] = $status;
+	}
+
+	/**
+	 * Retrieve the scan result recorded for a path, or null if no scan was recorded.
+	 */
+	public function getResult(string $path): ?int {
+		return $this->results[$this->normalizePath($path)] ?? null;
+	}
+
+	private function normalizePath(string $path): string {
+		return '/' . trim($path, '/');
+	}
+}

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -11,6 +11,7 @@ namespace OCA\Files_Antivirus\Tests;
 use OC\Files\Storage\Temporary;
 use OCA\Files_Antivirus\AppInfo\ConfigLexicon;
 use OCA\Files_Antivirus\AvirWrapper;
+use OCA\Files_Antivirus\ScannedPathsRegistry;
 use OCA\Files_Antivirus\Scanner\IScanner;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCA\Files_Antivirus\Status;
@@ -76,6 +77,7 @@ class AvirWrapperTest extends TestBase {
 			'userManager' => $this->createMock(IUserManager::class),
 			'block_unreachable' => false,
 			'request' => $this->createMock(IRequest::class),
+			'scannedPathsRegistry' => new ScannedPathsRegistry(),
 		]);
 
 		$this->config->expects($this->any())
@@ -179,6 +181,7 @@ class AvirWrapperTest extends TestBase {
 			'userManager' => $this->createMock(IUserManager::class),
 			'block_unreachable' => false,
 			'request' => $this->createMock(IRequest::class),
+			'scannedPathsRegistry' => new ScannedPathsRegistry(),
 		]);
 
 		$scanner = $this->getScanner(Status::SCANRESULT_UNSCANNABLE);
@@ -223,6 +226,7 @@ class AvirWrapperTest extends TestBase {
 			'userManager' => $this->createMock(IUserManager::class),
 			'block_unreachable' => $blockUnreachable,
 			'request' => $this->createMock(IRequest::class),
+			'scannedPathsRegistry' => new ScannedPathsRegistry(),
 		]);
 
 		$scanner = $this->getScanner(Status::SCANRESULT_UNCHECKED);
@@ -284,6 +288,7 @@ class AvirWrapperTest extends TestBase {
 			'userManager' => $userManager,
 			'block_unreachable' => false,
 			'request' => $this->createMock(IRequest::class),
+			'scannedPathsRegistry' => new ScannedPathsRegistry(),
 		]);
 
 		// Must not throw NoUserException, and scanning must still apply.
@@ -324,6 +329,7 @@ class AvirWrapperTest extends TestBase {
 			'userManager' => $userManager,
 			'block_unreachable' => false,
 			'request' => $this->createMock(IRequest::class),
+			'scannedPathsRegistry' => new ScannedPathsRegistry(),
 		]);
 
 		// Local owner, non-encrypted node: scanning still applies.
@@ -342,7 +348,7 @@ class AvirWrapperTest extends TestBase {
 			->method('error')
 			->with($this->stringContains('Simulated failure'));
 
-		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class), 'blockListedDirectories' => ['escape-scan'], 'groupFoldersEnabled' => false, 'e2eeEnabled' => false, ]) extends \OCA\Files_Antivirus\AvirWrapper {
+		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class), 'blockListedDirectories' => ['escape-scan'], 'groupFoldersEnabled' => false, 'e2eeEnabled' => false, 'scannedPathsRegistry' => new ScannedPathsRegistry(), ]) extends \OCA\Files_Antivirus\AvirWrapper {
 			public bool $connectionErrorCalled = false;
 			protected function handleConnectionError(string $path, bool $cleanup = false): void {
 				$this->connectionErrorCalled = true;

--- a/tests/Listener/NodeWrittenListenerTest.php
+++ b/tests/Listener/NodeWrittenListenerTest.php
@@ -12,6 +12,8 @@ namespace OCA\Files_Antivirus\Tests\Listener;
 use OCA\Files_Antivirus\Db\Item;
 use OCA\Files_Antivirus\Db\ItemMapper;
 use OCA\Files_Antivirus\Listener\NodeWrittenListener;
+use OCA\Files_Antivirus\ScannedPathsRegistry;
+use OCA\Files_Antivirus\Status;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
@@ -28,6 +30,7 @@ class NodeWrittenListenerTest extends TestCase {
 	private ItemMapper&MockObject $itemMapper;
 	private ITimeFactory&MockObject $timeFactory;
 	private LoggerInterface&MockObject $logger;
+	private ScannedPathsRegistry $registry;
 	private NodeWrittenListener $listener;
 
 	protected function setUp(): void {
@@ -35,11 +38,13 @@ class NodeWrittenListenerTest extends TestCase {
 		$this->itemMapper = $this->createMock(ItemMapper::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->registry = new ScannedPathsRegistry();
 
 		$this->listener = new NodeWrittenListener(
 			$this->itemMapper,
 			$this->timeFactory,
 			$this->logger,
+			$this->registry,
 		);
 	}
 
@@ -58,18 +63,21 @@ class NodeWrittenListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
-	public function testMarksFileAsScanned(): void {
+	public function testMarksFileAsScannedWhenClean(): void {
 		$fileId = 42;
+		$filePath = '/admin/files/foo.txt';
 		$checkTime = 1234567890;
+
+		$this->registry->registerResult($filePath, Status::SCANRESULT_CLEAN);
 
 		$event = $this->createMock(NodeWrittenEvent::class);
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn($fileId);
+		$file->method('getPath')->willReturn($filePath);
 		$event->method('getNode')->willReturn($file);
 
 		$this->timeFactory->method('getTime')->willReturn($checkTime);
 
-		// Simulate no existing entry
 		$this->itemMapper->expects(self::once())
 			->method('findByFileId')
 			->with($fileId)
@@ -86,13 +94,43 @@ class NodeWrittenListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
-	public function testUpdatesExistingEntry(): void {
+	public function testMarksFileAsScannedWhenUnscannable(): void {
 		$fileId = 42;
+		$filePath = '/admin/files/foo.zip';
 		$checkTime = 1234567890;
+
+		$this->registry->registerResult($filePath, Status::SCANRESULT_UNSCANNABLE);
 
 		$event = $this->createMock(NodeWrittenEvent::class);
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn($fileId);
+		$file->method('getPath')->willReturn($filePath);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn($checkTime);
+
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$this->itemMapper->expects(self::once())
+			->method('insert');
+
+		$this->listener->handle($event);
+	}
+
+	public function testUpdatesExistingEntry(): void {
+		$fileId = 42;
+		$filePath = '/admin/files/foo.txt';
+		$checkTime = 1234567890;
+
+		$this->registry->registerResult($filePath, Status::SCANRESULT_CLEAN);
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$file->method('getPath')->willReturn($filePath);
 		$event->method('getNode')->willReturn($file);
 
 		$this->timeFactory->method('getTime')->willReturn($checkTime);
@@ -121,19 +159,54 @@ class NodeWrittenListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
+	public function testDoesNotMarkFileWhenAVUnreachable(): void {
+		// When the scanner is unreachable and block_unreachable is false, the upload is
+		// allowed but AvirWrapper does NOT register a result. The listener must NOT mark
+		// the file so the background scanner can check it later.
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(42);
+		$file->method('getPath')->willReturn('/admin/files/foo.txt');
+		$event->method('getNode')->willReturn($file);
+
+		// Registry is empty — no scan result was recorded by AvirWrapper
+		$this->itemMapper->expects(self::never())->method('findByFileId');
+		$this->itemMapper->expects(self::never())->method('insert');
+
+		$this->listener->handle($event);
+	}
+
+	public function testDoesNotMarkFileWhenNotScanned(): void {
+		// Files that bypass shouldWrap() (e.g. E2EE, blocklisted dirs) are never
+		// registered in the registry, so the listener must leave them unmarked.
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(99);
+		$file->method('getPath')->willReturn('/admin/files/encrypted.txt');
+		$event->method('getNode')->willReturn($file);
+
+		$this->itemMapper->expects(self::never())->method('findByFileId');
+		$this->itemMapper->expects(self::never())->method('insert');
+
+		$this->listener->handle($event);
+	}
+
 	public function testHandlesInsertException(): void {
 		$fileId = 42;
+		$filePath = '/admin/files/foo.txt';
+
+		$this->registry->registerResult($filePath, Status::SCANRESULT_CLEAN);
 
 		$event = $this->createMock(NodeWrittenEvent::class);
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn($fileId);
+		$file->method('getPath')->willReturn($filePath);
 		$event->method('getNode')->willReturn($file);
 
 		$this->timeFactory->method('getTime')->willReturn(1234567890);
 
 		$this->itemMapper->expects(self::once())
 			->method('findByFileId')
-			->with($fileId)
 			->willThrowException(new DoesNotExistException(''));
 
 		$exception = new \Exception('DB error');
@@ -146,113 +219,5 @@ class NodeWrittenListenerTest extends TestCase {
 			->with(self::stringContains('DB error'));
 
 		$this->listener->handle($event);
-	}
-
-	/**
-	 * SECURITY TEST: When scanner is unreachable, file should NOT be marked as scanned.
-	 *
-	 * Scenario: block_unreachable: false
-	 * - AV scanner is unreachable/unavailable
-	 * - Upload is allowed to proceed (config: block_unreachable: false)
-	 * - File is written to disk
-	 * - NodeWrittenEvent fires
-	 *
-	 * Expected behavior (CORRECT - future fix):
-	 * - File must NOT be marked as scanned in database
-	 * - Background scanner will check it on next run
-	 * - This prevents infected files from being skipped if AV was temporarily unreachable
-	 *
-	 * Current behavior (BROKEN - THIS TEST DOCUMENTS THE BUG):
-	 * - File IS marked as scanned unconditionally ❌
-	 * - Background scanner will SKIP this file ❌
-	 * - Infected file could remain undetected ❌
-	 *
-	 * This test documents the security issue.
-	 * It will FAIL when the fix is implemented correctly.
-	 * When that happens, update the test to verify file is NOT marked.
-	 *
-	 * @todo When static tracking is implemented, change this test to verify file is NOT marked
-	 */
-	public function testUnreachableAVCurrentlyMarksFileUncorrectly(): void {
-		// This test documents INCORRECT behavior that needs fixing
-		$fileId = 42;
-		$checkTime = 1234567890;
-
-		$event = $this->createMock(NodeWrittenEvent::class);
-		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
-		$event->method('getNode')->willReturn($file);
-
-		$this->timeFactory->method('getTime')->willReturn($checkTime);
-
-		// When scanner is unreachable, current implementation still marks the file
-		// This is the SECURITY BUG - file should NOT be marked
-		$this->itemMapper->expects(self::once())
-			->method('findByFileId')
-			->with($fileId)
-			->willThrowException(new DoesNotExistException(''));
-
-		$this->itemMapper->expects(self::once())
-			->method('insert')
-			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
-				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
-			}));
-
-		$this->logger->expects(self::never())
-			->method('warning');
-
-		// File IS marked (WRONG), but should NOT be marked (CORRECT)
-		$this->listener->handle($event);
-	}
-
-	/**
-	 * IMPORTANT: This test documents a KNOWN ISSUE.
-	 *
-	 * The current implementation marks ALL uploaded files as scanned,
-	 * regardless of whether the AV scanner actually ran or what result it returned.
-	 *
-	 * This is a SECURITY VULNERABILITY:
-	 * - If AV is unreachable (block_unreachable: false), files are allowed but NOT scanned
-	 * - They should NOT be marked as scanned so background scanner checks them
-	 * - But NodeWrittenListener has no way to know if AV was unreachable vs actually scanned
-	 *
-	 * EXPECTED BEHAVIOR (not yet implemented):
-	 * - Only files with CLEAN or (UNSCANNABLE + block_unscannable: false) should be marked
-	 * - Files with UNCHECKED (unreachable), INFECTED should NOT be marked
-	 * - AvirWrapper should track which files were successfully scanned
-	 * - NodeWrittenListener should only mark files that were actually scanned
-	 *
-	 * @todo Implement scan status tracking mechanism
-	 */
-	public function testKnownIssueUnreachableAVMarkedAsScanned(): void {
-		// This test passes but documents incorrect behavior
-		$fileId = 42;
-		$checkTime = 1234567890;
-
-		$event = $this->createMock(NodeWrittenEvent::class);
-		$file = $this->createMock(File::class);
-		$file->method('getId')->willReturn($fileId);
-		$event->method('getNode')->willReturn($file);
-
-		$this->timeFactory->method('getTime')->willReturn($checkTime);
-
-		// AV was unreachable - file should NOT be marked as scanned
-		// But current implementation marks it anyway
-		$this->itemMapper->expects(self::once())
-			->method('findByFileId')
-			->with($fileId)
-			->willThrowException(new DoesNotExistException(''));
-
-		$this->itemMapper->expects(self::once())
-			->method('insert')
-			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
-				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
-			}));
-
-		// File is marked as scanned even though AV never ran
-		// This is the ISSUE - background scanner will skip this file
-		$this->listener->handle($event);
-
-		// TODO: Change this to verify file is NOT marked after implementing status tracking
 	}
 }

--- a/tests/Listener/NodeWrittenListenerTest.php
+++ b/tests/Listener/NodeWrittenListenerTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Tests\Listener;
+
+use OCA\Files_Antivirus\Db\Item;
+use OCA\Files_Antivirus\Db\ItemMapper;
+use OCA\Files_Antivirus\Listener\NodeWrittenListener;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\Files\Events\Node\NodeWrittenEvent;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+#[Group('DB')]
+class NodeWrittenListenerTest extends TestCase {
+	private ItemMapper&MockObject $itemMapper;
+	private ITimeFactory&MockObject $timeFactory;
+	private LoggerInterface&MockObject $logger;
+	private NodeWrittenListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->itemMapper = $this->createMock(ItemMapper::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->listener = new NodeWrittenListener(
+			$this->itemMapper,
+			$this->timeFactory,
+			$this->logger,
+		);
+	}
+
+	public function testIgnoresNonNodeWrittenEvent(): void {
+		$event = $this->createMock(Event::class);
+		$this->itemMapper->expects(self::never())->method('findByFileId');
+		$this->listener->handle($event);
+	}
+
+	public function testIgnoresFolders(): void {
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$folder = $this->createMock(Folder::class);
+		$event->method('getNode')->willReturn($folder);
+
+		$this->itemMapper->expects(self::never())->method('findByFileId');
+		$this->listener->handle($event);
+	}
+
+	public function testMarksFileAsScanned(): void {
+		$fileId = 42;
+		$checkTime = 1234567890;
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn($checkTime);
+
+		// Simulate no existing entry
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$this->itemMapper->expects(self::once())
+			->method('insert')
+			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
+				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
+			}));
+
+		$this->logger->expects(self::never())->method('warning');
+
+		$this->listener->handle($event);
+	}
+
+	public function testUpdatesExistingEntry(): void {
+		$fileId = 42;
+		$checkTime = 1234567890;
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn($checkTime);
+
+		$existingItem = new Item();
+		$existingItem->setFileid($fileId);
+		$existingItem->setCheckTime(999);
+
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willReturn($existingItem);
+
+		$this->itemMapper->expects(self::once())
+			->method('delete')
+			->with($existingItem);
+
+		$this->itemMapper->expects(self::once())
+			->method('insert')
+			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
+				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
+			}));
+
+		$this->logger->expects(self::never())->method('warning');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandlesInsertException(): void {
+		$fileId = 42;
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn(1234567890);
+
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$exception = new \Exception('DB error');
+		$this->itemMapper->expects(self::once())
+			->method('insert')
+			->willThrowException($exception);
+
+		$this->logger->expects(self::once())
+			->method('warning')
+			->with(self::stringContains('DB error'));
+
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * SECURITY TEST: When scanner is unreachable, file should NOT be marked as scanned.
+	 *
+	 * Scenario: block_unreachable: false
+	 * - AV scanner is unreachable/unavailable
+	 * - Upload is allowed to proceed (config: block_unreachable: false)
+	 * - File is written to disk
+	 * - NodeWrittenEvent fires
+	 *
+	 * Expected behavior (CORRECT - future fix):
+	 * - File must NOT be marked as scanned in database
+	 * - Background scanner will check it on next run
+	 * - This prevents infected files from being skipped if AV was temporarily unreachable
+	 *
+	 * Current behavior (BROKEN - THIS TEST DOCUMENTS THE BUG):
+	 * - File IS marked as scanned unconditionally ❌
+	 * - Background scanner will SKIP this file ❌
+	 * - Infected file could remain undetected ❌
+	 *
+	 * This test documents the security issue.
+	 * It will FAIL when the fix is implemented correctly.
+	 * When that happens, update the test to verify file is NOT marked.
+	 *
+	 * @todo When static tracking is implemented, change this test to verify file is NOT marked
+	 */
+	public function testUnreachableAVCurrentlyMarksFileUncorrectly(): void {
+		// This test documents INCORRECT behavior that needs fixing
+		$fileId = 42;
+		$checkTime = 1234567890;
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn($checkTime);
+
+		// When scanner is unreachable, current implementation still marks the file
+		// This is the SECURITY BUG - file should NOT be marked
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$this->itemMapper->expects(self::once())
+			->method('insert')
+			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
+				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
+			}));
+
+		$this->logger->expects(self::never())
+			->method('warning');
+
+		// File IS marked (WRONG), but should NOT be marked (CORRECT)
+		$this->listener->handle($event);
+	}
+
+	/**
+	 * IMPORTANT: This test documents a KNOWN ISSUE.
+	 *
+	 * The current implementation marks ALL uploaded files as scanned,
+	 * regardless of whether the AV scanner actually ran or what result it returned.
+	 *
+	 * This is a SECURITY VULNERABILITY:
+	 * - If AV is unreachable (block_unreachable: false), files are allowed but NOT scanned
+	 * - They should NOT be marked as scanned so background scanner checks them
+	 * - But NodeWrittenListener has no way to know if AV was unreachable vs actually scanned
+	 *
+	 * EXPECTED BEHAVIOR (not yet implemented):
+	 * - Only files with CLEAN or (UNSCANNABLE + block_unscannable: false) should be marked
+	 * - Files with UNCHECKED (unreachable), INFECTED should NOT be marked
+	 * - AvirWrapper should track which files were successfully scanned
+	 * - NodeWrittenListener should only mark files that were actually scanned
+	 *
+	 * @todo Implement scan status tracking mechanism
+	 */
+	public function testKnownIssueUnreachableAVMarkedAsScanned(): void {
+		// This test passes but documents incorrect behavior
+		$fileId = 42;
+		$checkTime = 1234567890;
+
+		$event = $this->createMock(NodeWrittenEvent::class);
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn($fileId);
+		$event->method('getNode')->willReturn($file);
+
+		$this->timeFactory->method('getTime')->willReturn($checkTime);
+
+		// AV was unreachable - file should NOT be marked as scanned
+		// But current implementation marks it anyway
+		$this->itemMapper->expects(self::once())
+			->method('findByFileId')
+			->with($fileId)
+			->willThrowException(new DoesNotExistException(''));
+
+		$this->itemMapper->expects(self::once())
+			->method('insert')
+			->with(self::callback(function (Item $item) use ($fileId, $checkTime) {
+				return $item->getFileid() === $fileId && $item->getCheckTime() === $checkTime;
+			}));
+
+		// File is marked as scanned even though AV never ran
+		// This is the ISSUE - background scanner will skip this file
+		$this->listener->handle($event);
+
+		// TODO: Change this to verify file is NOT marked after implementing status tracking
+	}
+}


### PR DESCRIPTION
- Fixes #71
  - Adds NodeWrittenListener to mark files after uploading them
  - Adds ScannedPathsRegistry to track scanned files within the request

### Commit 1

The initial implementation tried to mark files as scanned immediately after the AV scan in AvirWrapper, but this failed because:

 - Files are not yet in oc_filecache during the write operation
 - File IDs don't exist until after the write completes and the cache is synced
 - Attempting to mark files with invalid IDs simply fails silently

Additionally, the follow-up NodeWrittenListener that was introduced to fix the timing issue marked every uploaded file as scanned unconditionally, with no knowledge of whether the scan actually succeeded — meaning unreachable-AV uploads were still silently marked as clean.

### Commit 2

Using NodeWrittenEvent to mark files after they're fully written and synced, combined with a ScannedPathsRegistry — a request-scoped in-memory map that bridges the scanning layer and the post-upload persistence layer:
  1. AvirWrapper writes to the registry only when a file is genuinely accepted after scanning (status CLEAN, or UNSCANNABLE with block_unscannable disabled). UNCHECKED results (unreachable scanner) are deliberately not registered.
  2. NodeWrittenListener fires after the file is persisted and oc_filecache is updated — at this point the file has a valid ID. It checks the registry before writing to the database. If no scan result is present, it does nothing — leaving  the file for the background scanner.

The registry is a plain PHP object resolved as a per-request singleton by Nextcloud's DI container, so it is naturally shared between FilesystemSetupListener (which constructs AvirWrapper) and NodeWrittenListener without any explicit container registration.

Nextcloud DAV uploads use hashed temporary filenames (e.g. ab3cd4.ocTransferId123.part), making it impossible to recover the real filename from the storage path alone. getRegistryPath() detects this case and falls back to the DAV request URI (/dav/files/{user}/{real_path}), transforming it to match the absolute path returned by Node::getPath() (/{user}/files/{real_path}).

Testing

 - Upload with reachable scanner → file marked as scanned ✅
 - Upload with unreachable scanner (block_unreachable: false) → file not marked, picked up by background scanner ✅
 - Upload with unreachable scanner (block_unreachable: true) → upload blocked ✅

After upload, verify the file is marked:

 SELECT fileid, check_time FROM oc_files_antivirus WHERE fileid = <FILE_ID>;

The file should have a check_time timestamp instead of NULL.