### PR TITLE
fix: init scanner before doing filesystem operations

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -11,6 +11,7 @@ use OC\Files\Storage\Wrapper\Wrapper;
 use OCA\Files_Antivirus\Activity\Provider;
 use OCA\Files_Antivirus\AppInfo\Application;
 use OCA\Files_Antivirus\Event\ScanStateEvent;
+use OCA\Files_Antivirus\Scanner\IScanner;
 use OCA\Files_Antivirus\Scanner\ScannerFactory;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\GroupFolders\Folder\FolderManager;
@@ -93,29 +94,42 @@ class AvirWrapper extends Wrapper {
 		});
 	}
 
+	private function getAvScanner(string $path): IScanner {
+		try {
+			$scanner = $this->scannerFactory->getScanner($this->getPathForScanner($path));
+			$scanner->initScanner();
+			return $scanner;
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			if ($this->blockUnReachable) {
+				$this->handleConnectionError($path);
+			} else {
+				return $this->scannerFactory->getDummyScanner();
+			}
+		}
+	}
+
 	/**
 	 * Asynchronously scan data that are written to the file
 	 * @return resource | false
 	 */
 	public function fopen(string $path, string $mode) {
-		$stream = $this->storage->fopen($path, $mode);
-
-		/*
-		 * Only check when
-		 *  - it is a resource
-		 *  - it is a writing mode
-		 *  - if it is a homestorage it starts with files/
-		 *  - if it is not a homestorage we always wrap (external storages)
-		 */
-		if ($this->shouldWrap($path) && is_resource($stream) && $this->isWritingMode($mode)) {
-			$stream = $this->wrapSteam($path, $stream);
+		if ($this->shouldWrap($path) && $this->isWritingMode($mode)) {
+			$scanner = $this->getAvScanner($path);
+			$stream = $this->storage->fopen($path, $mode);
+			if (is_resource($stream)) {
+				$stream = $this->wrapSteam($path, $stream, $scanner);
+			}
+			return $stream;
+		} else {
+			return $this->storage->fopen($path, $mode);
 		}
-		return $stream;
 	}
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {
 		if ($this->shouldWrap($path)) {
-			$stream = $this->wrapSteam($path, $stream);
+			$scanner = $this->getAvScanner($path);
+			$stream = $this->wrapSteam($path, $stream, $scanner);
 		}
 		return parent::writeStream($path, $stream, $size);
 	}
@@ -192,44 +206,34 @@ class AvirWrapper extends Wrapper {
 		return substr($this->request->getPathInfo(), strlen($davFilesPrefix));
 	}
 
-	public function wrapSteam(string $path, $stream) {
-		try {
-			$scanner = $this->scannerFactory->getScanner($this->getPathForScanner($path));
-			$scanner->initScanner();
-			$amountRead = 0;
-			return CallbackReadDataWrapper::wrap(
-				$stream,
-				function ($count, $data) use ($scanner, $stream, &$amountRead) {
-					$pos = ftell($stream);
-					// don't scan twice when the stream is seeked backwards during reading
-					if ($pos > $amountRead) {
-						$scanner->onAsyncData($data);
-						$amountRead = $pos;
-					}
-				},
-				function ($data) use ($scanner) {
+	public function wrapSteam(string $path, $stream, IScanner $scanner) {
+		$amountRead = 0;
+		return CallbackReadDataWrapper::wrap(
+			$stream,
+			function ($count, $data) use ($scanner, $stream, &$amountRead) {
+				$pos = ftell($stream);
+				// don't scan twice when the stream is seeked backwards during reading
+				if ($pos > $amountRead) {
 					$scanner->onAsyncData($data);
-				},
-				function () use ($scanner, $path) {
-					$status = $scanner->completeAsyncScan();
-					if ($status->getNumericStatus() === Status::SCANRESULT_INFECTED) {
-						$this->handleInfected($path, $status);
-					}
-					if ($this->blockUnscannable && $status->getNumericStatus() === Status::SCANRESULT_UNSCANNABLE) {
-						$this->handleInfected($path, $status);
-					}
-					if ($this->blockUnReachable && $status->getNumericStatus() === Status::SCANRESULT_UNCHECKED) {
-						$this->handleConnectionError($path);
-					}
+					$amountRead = $pos;
 				}
-			);
-		} catch (\Exception $e) {
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			if ($this->blockUnReachable) {
-				$this->handleConnectionError($path);
+			},
+			function ($data) use ($scanner) {
+				$scanner->onAsyncData($data);
+			},
+			function () use ($scanner, $path) {
+				$status = $scanner->completeAsyncScan();
+				if ($status->getNumericStatus() === Status::SCANRESULT_INFECTED) {
+					$this->handleInfected($path, $status);
+				}
+				if ($this->blockUnscannable && $status->getNumericStatus() === Status::SCANRESULT_UNSCANNABLE) {
+					$this->handleInfected($path, $status);
+				}
+				if ($this->blockUnReachable && $status->getNumericStatus() === Status::SCANRESULT_UNCHECKED) {
+					$this->handleConnectionError($path, true);
+				}
 			}
-		}
-		return $stream;
+		);
 	}
 
 	/**
@@ -327,18 +331,20 @@ class AvirWrapper extends Wrapper {
 	/**
 	 * @throws InvalidContentException
 	 */
-	protected function handleConnectionError(string $path): void {
-		//prevent from going to trashbin
-		if ($this->trashEnabled) {
-			$trashManager = Server::get(ITrashManager::class);
-			$trashManager->pauseTrash();
-		}
+	protected function handleConnectionError(string $path, bool $cleanup = false): void {
+		if ($cleanup) {
+			//prevent from going to trashbin
+			if ($this->trashEnabled) {
+				$trashManager = Server::get(ITrashManager::class);
+				$trashManager->pauseTrash();
+			}
 
-		$this->unlink($path);
+			$this->unlink($path);
 
-		if ($this->trashEnabled) {
-			$trashManager = Server::get(ITrashManager::class);
-			$trashManager->resumeTrash();
+			if ($this->trashEnabled) {
+				$trashManager = Server::get(ITrashManager::class);
+				$trashManager->resumeTrash();
+			}
 		}
 
 		throw new InvalidContentException(

--- a/lib/Scanner/DummyScanner.php
+++ b/lib/Scanner/DummyScanner.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files_Antivirus\Scanner;
+
+use OCA\Files_Antivirus\Item;
+use OCA\Files_Antivirus\Status;
+use OCA\Files_Antivirus\StatusFactory;
+use OCP\IRequest;
+
+/**
+ * A dummy scanner that always returns "clean"
+ */
+class DummyScanner implements IScanner {
+	public function __construct(
+		private readonly StatusFactory $statusFactory,
+	) {
+
+	}
+
+	#[\Override]
+	public function getStatus(): Status {
+		$status = $this->statusFactory->newStatus();
+		$status->setNumericStatus(Status::SCANRESULT_CLEAN);
+		return $status;
+	}
+
+	/**
+	 * Synchronous scan
+	 *
+	 * @param Item $item
+	 * @return Status
+	 */
+	#[\Override]
+	public function scan(Item $item): Status {
+		return $this->getStatus();
+	}
+
+	#[\Override]
+	public function scanString(string $data): Status {
+		return $this->getStatus();
+	}
+
+	#[\Override]
+	public function onAsyncData(string $data): void {
+		// noop
+	}
+
+	#[\Override]
+	public function completeAsyncScan(): Status {
+		return $this->getStatus();
+	}
+
+	#[\Override]
+	public function initScanner(): void {
+		// noop
+	}
+
+	#[\Override]
+	public function setDebugCallback(callable $callback): void {
+		// unsupported
+	}
+
+	public function setPath(string $path): void {
+		// noop
+	}
+
+	public function setRequest(IRequest $request): void {
+		// noop
+	}
+}

--- a/lib/Scanner/ScannerFactory.php
+++ b/lib/Scanner/ScannerFactory.php
@@ -53,4 +53,8 @@ class ScannerFactory {
 		}
 		return $scanner;
 	}
+
+	public function getDummyScanner(): IScanner {
+		return $this->serverContainer->get(DummyScanner::class);
+	}
 }

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -128,7 +128,6 @@ class AvirWrapperTest extends TestBase {
 
 	public function testCleanFileShouldAllowUpload(): void {
 		$scanner = $this->getScanner(Status::SCANRESULT_CLEAN);
-		$this->scannerFactory->method('getScanner')->willReturn($scanner);
 
 		$stream = fopen('php://memory', 'rwb');
 		$this->assertNotFalse($stream);
@@ -136,7 +135,7 @@ class AvirWrapperTest extends TestBase {
 		rewind($stream);
 
 		// Should not throw exception
-		$result = $this->wrappedStorage->wrapSteam('/files/test.txt', $stream);
+		$result = $this->wrappedStorage->wrapSteam('/files/test.txt', $stream, $scanner);
 		$this->assertNotNull($result);
 		// Consume stream to trigger scanning callbacks
 		stream_get_contents($result);
@@ -145,7 +144,6 @@ class AvirWrapperTest extends TestBase {
 
 	public function testInfectedFileShouldBlockUpload(): void {
 		$scanner = $this->getScanner(Status::SCANRESULT_INFECTED);
-		$this->scannerFactory->method('getScanner')->willReturn($scanner);
 
 		$stream = fopen('php://memory', 'rwb');
 		$this->assertNotFalse($stream);
@@ -154,7 +152,7 @@ class AvirWrapperTest extends TestBase {
 
 		// wrapSteam catches exceptions and logs them, doesn't propagate
 		// The file would be handled (logged) but wrapped stream is returned
-		$result = $this->wrappedStorage->wrapSteam('/files/test.txt', $stream);
+		$result = $this->wrappedStorage->wrapSteam('/files/test.txt', $stream, $scanner);
 		$this->assertNotNull($result);
 		// Consume stream to trigger scanning callbacks
 		stream_get_contents($result);
@@ -184,7 +182,6 @@ class AvirWrapperTest extends TestBase {
 		]);
 
 		$scanner = $this->getScanner(Status::SCANRESULT_UNSCANNABLE);
-		$this->scannerFactory->method('getScanner')->willReturn($scanner);
 
 		$stream = fopen('php://memory', 'rwb');
 		$this->assertNotFalse($stream);
@@ -192,7 +189,7 @@ class AvirWrapperTest extends TestBase {
 		rewind($stream);
 
 		// wrapSteam catches exceptions and doesn't propagate them
-		$result = $wrappedStorage->wrapSteam('/files/test.txt', $stream);
+		$result = $wrappedStorage->wrapSteam('/files/test.txt', $stream, $scanner);
 		$this->assertNotNull($result);
 		// Consume stream to trigger scanning callbacks
 		stream_get_contents($result);
@@ -229,7 +226,6 @@ class AvirWrapperTest extends TestBase {
 		]);
 
 		$scanner = $this->getScanner(Status::SCANRESULT_UNCHECKED);
-		$this->scannerFactory->method('getScanner')->willReturn($scanner);
 
 		$stream = fopen('php://memory', 'rwb');
 		$this->assertNotFalse($stream);
@@ -238,7 +234,7 @@ class AvirWrapperTest extends TestBase {
 
 		// wrapSteam catches exceptions and doesn't propagate them
 		// Exception handling depends on block_unreachable config
-		$result = $wrappedStorage->wrapSteam('/files/test.txt', $stream);
+		$result = $wrappedStorage->wrapSteam('/files/test.txt', $stream, $scanner);
 		$this->assertNotNull($result);
 		// Consume stream to trigger scanning callbacks
 		stream_get_contents($result);
@@ -250,47 +246,6 @@ class AvirWrapperTest extends TestBase {
 			'unreachable AV with block disabled' => [false, 'Upload allowed when unreachable'],
 			'unreachable AV with block enabled' => [true, 'Upload blocked when unreachable'],
 		];
-	}
-
-	public function testWrapStreamWithNullMountPoint(): void {
-		$scannerFactory = $this->createMock(ScannerFactory::class);
-
-		$wrapper = new AvirWrapper([
-			'storage' => $this->storage,
-			'scannerFactory' => $scannerFactory,
-			'l10n' => $this->l10n,
-			'logger' => $this->logger,
-			'activityManager' => $this->createMock(IManager::class),
-			'isHomeStorage' => true,
-			'eventDispatcher' => $this->createMock(EventDispatcherInterface::class),
-			'trashEnabled' => true,
-			'groupFoldersEnabled' => false,
-			'e2eeEnabled' => false,
-			'blockListedDirectories' => ['escape-scan', 'dont-scan'],
-			'mount_point' => null,
-			'block_unscannable' => false,
-			'userManager' => $this->createMock(IUserManager::class),
-			'block_unreachable' => false,
-			'request' => $this->createMock(IRequest::class),
-		]);
-
-		$scanner = $this->getScanner();
-		$scannerFactory->expects(self::once())
-			->method('getScanner')
-			->with(null)
-			->willReturn($scanner);
-		$scanner->expects(self::once())
-			->method('initScanner')
-			->willThrowException(new \Exception('Skip actual wrapping (hackity hack)'));
-
-		$this->logger->expects(self::once())
-			->method('error');
-
-		$expected = fopen('php://memory', 'rwb');
-		$this->assertNotFalse($expected);
-		$actual = $wrapper->wrapSteam('/foo/bar.baz', $expected);
-		$this->assertEquals($expected, $actual);
-		fclose($expected);
 	}
 
 	public function testHandleConnectionErrorIsTriggered(): void {
@@ -307,7 +262,7 @@ class AvirWrapperTest extends TestBase {
 
 		$wrapper = new class([ 'storage' => $this->storage, 'scannerFactory' => $scannerFactory, 'l10n' => $this->l10n, 'logger' => $logger, 'activityManager' => $this->createMock(\OCP\Activity\IManager::class), 'isHomeStorage' => false, 'eventDispatcher' => $this->createMock(\OCP\EventDispatcher\IEventDispatcher::class), 'trashEnabled' => false, 'mount_point' => '/', 'block_unscannable' => false, 'userManager' => $this->createMock(IUserManager::class), 'block_unreachable' => 'yes', 'request' => $this->createMock(IRequest::class), 'blockListedDirectories' => ['escape-scan'], 'groupFoldersEnabled' => false, 'e2eeEnabled' => false, ]) extends \OCA\Files_Antivirus\AvirWrapper {
 			public bool $connectionErrorCalled = false;
-			protected function handleConnectionError(string $path): void {
+			protected function handleConnectionError(string $path, bool $cleanup = false): void {
 				$this->connectionErrorCalled = true;
 				parent::handleConnectionError($path);
 			}


### PR DESCRIPTION
this saves from us from having to cleanup a potentially newly created file when the scanner is unreachable

And prevents deleting exist files that would be overwritten.
