### PR TITLE
pass file size to scanner when known

### DIFF
--- a/lib/Scanner/ICAP.php
+++ b/lib/Scanner/ICAP.php
@@ -100,7 +100,7 @@ class ICAP extends ScannerBase {
 					'Host: nextcloud',
 				], [
 					'HTTP/1.0 200 OK',
-					'Content-Length: 1', // a dummy, non-zero, content length seems to be enough
+					'Content-Length: ' . ($this->size ?? 1), // a dummy, non-zero, content length seems to be enough
 				]);
 			}
 			$this->icapRequest->init();


### PR DESCRIPTION
If the size of the to-be-scanned object is known in advanced, pass it to the scanner to help it out

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
