### PR TITLE
fix: handle federated share owners that don't resolve to a local user

### DIFF
--- a/lib/AvirWrapper.php
+++ b/lib/AvirWrapper.php
@@ -169,7 +169,13 @@ class AvirWrapper extends Wrapper {
 			$parentId = $this->storage->getCache()->getParentId($path);
 			$rootFolder = \OCP\Server::get(IRootFolder::class);
 			$owner = $this->storage->getOwner($path);
-			if ($owner !== false) {
+			// For a received federated share getOwner() returns a cloud id
+			// (uuid@remote), which is not a local user. Resolving it via
+			// getUserFolder() would throw NoUserException and surface as an
+			// HTTP 500 on every read/download. Skip the E2EE check for a
+			// non-local owner: a federated file is not a local E2EE file, and
+			// normal scanning still applies below (fail toward scanning).
+			if ($owner !== false && $this->userManager->get($owner) !== null) {
 				$userFolder = $rootFolder->getUserFolder($owner);
 				$node = $userFolder->getFirstNodeById($parentId);
 				if ($node !== null && $node->isEncrypted()) {

--- a/lib/Item.php
+++ b/lib/Item.php
@@ -81,17 +81,24 @@ class Item {
 
 		$message = $shouldDelete ? Provider::MESSAGE_FILE_DELETED : '';
 
-		$userFolder = $this->rootFolder->getUserFolder($this->file->getOwner()->getUID());
-		$path = $userFolder->getRelativePath($this->file->getPath());
+		// A received federated share has a remote owner that does not resolve
+		// to a local user, so there is no local account to attribute the
+		// activity to. Skip the per-user activity in that case; the file is
+		// still logged and deleted/flagged below.
+		$owner = $this->file->getOwner();
+		if ($owner !== null) {
+			$userFolder = $this->rootFolder->getUserFolder($owner->getUID());
+			$path = $userFolder->getRelativePath($this->file->getPath());
 
-		$activity = $this->activityManager->generateEvent();
-		$activity->setApp(Application::APP_NAME)
-			->setSubject(Provider::SUBJECT_VIRUS_DETECTED_SCAN, [$status->getDetails()])
-			->setMessage($message)
-			->setObject('file', $this->file->getId(), $path ?? '')
-			->setAffectedUser($this->file->getOwner()->getUID())
-			->setType(Provider::TYPE_VIRUS_DETECTED);
-		$this->activityManager->publish($activity);
+			$activity = $this->activityManager->generateEvent();
+			$activity->setApp(Application::APP_NAME)
+				->setSubject(Provider::SUBJECT_VIRUS_DETECTED_SCAN, [$status->getDetails()])
+				->setMessage($message)
+				->setObject('file', $this->file->getId(), $path ?? '')
+				->setAffectedUser($owner->getUID())
+				->setType(Provider::TYPE_VIRUS_DETECTED);
+			$this->activityManager->publish($activity);
+		}
 
 		if ($shouldDelete) {
 			if ($this->isCron) {
@@ -231,8 +238,10 @@ class Item {
 	public function logDebug(string $message): void {
 		$this->logger->debug($message . $this->generateExtraInfo(), [
 			'app' => 'files_antivirus',
-			'userId' => $this->file->getOwner()->getUID(),
-			'userName' => $this->file->getOwner()->getDisplayName(),
+			// Owner is null for a received federated share (remote cloud id),
+			// so guard it like generateExtraInfo() above already does.
+			'userId' => $this->file->getOwner()?->getUID(),
+			'userName' => $this->file->getOwner()?->getDisplayName(),
 			'fileId' => $this->file->getId(),
 			'filePath' => $this->file->getPath(),
 			'fileName' => $this->file->getName(),
@@ -246,8 +255,8 @@ class Item {
 	public function logNotice(string $message): void {
 		$this->logger->notice($message . $this->generateExtraInfo(), [
 			'app' => 'files_antivirus',
-			'userId' => $this->file->getOwner()->getUID(),
-			'userName' => $this->file->getOwner()->getDisplayName(),
+			'userId' => $this->file->getOwner()?->getUID(),
+			'userName' => $this->file->getOwner()?->getDisplayName(),
 			'fileId' => $this->file->getId(),
 			'filePath' => $this->file->getPath(),
 			'fileName' => $this->file->getName(),
@@ -261,8 +270,8 @@ class Item {
 	public function logError(string $message): void {
 		$this->logger->error($message . $this->generateExtraInfo(), [
 			'app' => 'files_antivirus',
-			'userId' => $this->file->getOwner()->getUID(),
-			'userName' => $this->file->getOwner()->getDisplayName(),
+			'userId' => $this->file->getOwner()?->getUID(),
+			'userName' => $this->file->getOwner()?->getDisplayName(),
 			'fileId' => $this->file->getId(),
 			'filePath' => $this->file->getPath(),
 			'fileName' => $this->file->getName(),

--- a/tests/AvirWrapperTest.php
+++ b/tests/AvirWrapperTest.php
@@ -248,6 +248,88 @@ class AvirWrapperTest extends TestBase {
 		];
 	}
 
+	/**
+	 * Regression for the federated-share 500 (NoUserException): with the E2EE app
+	 * enabled, shouldWrap() resolves the file owner. For a received federated share
+	 * getOwner() returns a cloud id (uuid@remote), which is not a local user, so
+	 * getUserFolder() used to throw and Sabre turned it into an HTTP 500 on every
+	 * read/download. The owner must be guarded so we skip E2EE detection instead of
+	 * throwing, and normal scanning still applies (fail toward scanning, not bypass).
+	 */
+	public function testShouldWrapFederatedOwnerDoesNotThrow(): void {
+		$storage = new class([]) extends Temporary {
+			public function getOwner(string $path): string|false {
+				return 'uuid@remote.example';
+			}
+		};
+
+		$userManager = $this->createMock(IUserManager::class);
+		// A federated cloud id does not resolve to a local user.
+		$userManager->method('get')->willReturn(null);
+
+		$wrappedStorage = new AvirWrapper([
+			'storage' => $storage,
+			'scannerFactory' => $this->scannerFactory,
+			'l10n' => $this->l10n,
+			'logger' => $this->logger,
+			'activityManager' => $this->createMock(IManager::class),
+			'isHomeStorage' => true,
+			'eventDispatcher' => $this->createMock(EventDispatcherInterface::class),
+			'trashEnabled' => true,
+			'groupFoldersEnabled' => false,
+			'e2eeEnabled' => true,
+			'blockListedDirectories' => [],
+			'mount_point' => '/user/files/',
+			'block_unscannable' => false,
+			'userManager' => $userManager,
+			'block_unreachable' => false,
+			'request' => $this->createMock(IRequest::class),
+		]);
+
+		// Must not throw NoUserException, and scanning must still apply.
+		self::assertTrue($wrappedStorage->shouldWrap('/files/shared.pdf'));
+	}
+
+	/**
+	 * A local owner is still resolved through the E2EE detection branch, and a
+	 * non-encrypted file still gets scanned (guarding the federated case must not
+	 * disable scanning for local content).
+	 */
+	public function testShouldWrapLocalOwnerStillScans(): void {
+		$storage = new class([]) extends Temporary {
+			public function getOwner(string $path): string|false {
+				return AvirWrapperTest::UID;
+			}
+		};
+
+		$userManager = $this->createMock(IUserManager::class);
+		$userManager->method('get')
+			->with(self::UID)
+			->willReturn($this->createMock(\OCP\IUser::class));
+
+		$wrappedStorage = new AvirWrapper([
+			'storage' => $storage,
+			'scannerFactory' => $this->scannerFactory,
+			'l10n' => $this->l10n,
+			'logger' => $this->logger,
+			'activityManager' => $this->createMock(IManager::class),
+			'isHomeStorage' => true,
+			'eventDispatcher' => $this->createMock(EventDispatcherInterface::class),
+			'trashEnabled' => true,
+			'groupFoldersEnabled' => false,
+			'e2eeEnabled' => true,
+			'blockListedDirectories' => [],
+			'mount_point' => '/' . self::UID . '/files/',
+			'block_unscannable' => false,
+			'userManager' => $userManager,
+			'block_unreachable' => false,
+			'request' => $this->createMock(IRequest::class),
+		]);
+
+		// Local owner, non-encrypted node: scanning still applies.
+		self::assertTrue($wrappedStorage->shouldWrap('/files/local.txt'));
+	}
+
 	public function testHandleConnectionErrorIsTriggered(): void {
 		// Simulate ScannerFactory throwing an exception
 		$scannerFactory = $this->createMock(ScannerFactory::class);

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Tests;
+
+use OCA\Files_Antivirus\Db\ItemMapper;
+use OCA\Files_Antivirus\Item;
+use OCP\Activity\IManager as ActivityManager;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class ItemTest extends TestCase {
+	private File&MockObject $file;
+	private ActivityManager&MockObject $activityManager;
+
+	private function buildItem(): Item {
+		$this->file = $this->createMock(File::class);
+		$this->file->method('getId')->willReturn(42);
+		$this->file->method('getPath')->willReturn('/cyprien/files/shared/test.docx');
+		$this->file->method('getName')->willReturn('test.docx');
+		$this->file->method('getUploadTime')->willReturn(0);
+		// A received federated share has a remote owner that does not resolve
+		// to a local user: Node::getOwner() returns null.
+		$this->file->method('getOwner')->willReturn(null);
+
+		$this->activityManager = $this->createMock(ActivityManager::class);
+
+		return new Item(
+			$this->createMock(IAppConfig::class),
+			$this->activityManager,
+			$this->createMock(ItemMapper::class),
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(IRootFolder::class),
+			$this->createMock(IAppManager::class),
+			$this->file,
+			$this->createMock(ITimeFactory::class),
+			true,
+		);
+	}
+
+	/**
+	 * Regression for #614: the background scan logs the file being scanned via
+	 * these helpers. With a federated (owner-less) file they used to call
+	 * getOwner()->getUID() and crash the whole scan run.
+	 */
+	public function testLogHelpersSurviveNullOwner(): void {
+		$item = $this->buildItem();
+
+		$item->logDebug('scanning');
+		$item->logNotice('scanning');
+		$item->logError('scanning');
+
+		// No TypeError / "getUID() on null": reaching here is the assertion.
+		$this->addToAssertionCount(1);
+	}
+
+	/**
+	 * An infected federated file has no local user to attribute activity to,
+	 * so publishing is skipped rather than crashing on getOwner()->getUID().
+	 */
+	public function testProcessInfectedSkipsActivityForNullOwner(): void {
+		$item = $this->buildItem();
+
+		// Nothing to attribute: no activity event should be published.
+		$this->activityManager->expects($this->never())->method('publish');
+
+		$status = $this->createMock(\OCA\Files_Antivirus\Status::class);
+		$status->method('getDetails')->willReturn('Eicar-Test-Signature');
+
+		$item->processInfected($status);
+	}
+}


### PR DESCRIPTION
* Resolves: #614

## Bug 

Federated shares broke files_antivirus in two ways, both because a received federated share's owner is a remote cloud id that `userManager->get()` can't resolve to a local user.

## Fix

Guard the owner in both paths. Local content is scanned exactly as before; a federated file with no local owner is skipped instead of crashing. The log helpers now match the null check `generateExtraInfo()` already does. `processInfected()` still logs and deletes/flags the file, it just skips the per-user activity.

## AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI