### PR TITLE
chore: bump version to 6.3.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 This application inspects files that are uploaded to Nextcloud for viruses before they are written to the Nextcloud storage. If a file is identified as a virus, it is either logged or not uploaded to the server. The application relies on the underlying ClamAV virus scanning engine, which the admin points Nextcloud to when configuring the application. Alternatively, a Kaspersky Scan Engine can be configured, which has to run on a separate server.
 For this app to be effective, the ClamAV virus definitions should be kept up to date. Also note that enabling this app will impact system performance as additional processing is required for every upload. More information is available in the Antivirus documentation.
 	]]></description>
-	<version>6.3.0</version>
+	<version>6.3.1</version>
 	<licence>agpl</licence>
 
 	<author>Manuel Delgado</author>


### PR DESCRIPTION
Bump info.xml to 6.3.1. The bump was accidentally left out of #653, which only carried the cherry-picked fix, so stable6.3 still reports 6.3.0.