### PR TITLE
fix(activity): throw UnknownActivityException for unhandled events

### DIFF
--- a/lib/Activity/Provider.php
+++ b/lib/Activity/Provider.php
@@ -8,6 +8,7 @@
 namespace OCA\Files_Antivirus\Activity;
 
 use OCA\Files_Antivirus\AppInfo\Application;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IProvider;
 use OCP\IURLGenerator;
@@ -31,7 +32,7 @@ class Provider implements IProvider {
 	#[\Override]
 	public function parse($language, IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		if ($event->getApp() !== Application::APP_NAME || $event->getType() !== self::TYPE_VIRUS_DETECTED) {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		$l = $this->languageFactory->get('files_antivirus', $language);


### PR DESCRIPTION
Fixes #638

`IProvider::parse()` has been documented to throw `UnknownActivityException` since Nextcloud 30 — throwing `\InvalidArgumentException` directly is deprecated and the activity manager logs it at error level:

> `@since 30.0.0` Providers should throw `UnknownActivityException` instead of `\InvalidArgumentException` when they did not handle the event. Throwing `\InvalidArgumentException` directly is deprecated and will be logged as an error.

The provider throws whenever the event is not a files_antivirus `virus_detected` one, which is the case for every foreign activity event it is offered, so `nextcloud.log` fills up with errors on any instance that has other activity. Three people reported it on the issue between 22 July and 4 August, on 6.3.2 / Nextcloud 34.

The app requires Nextcloud 32 at minimum, so the exception class is always available — no compatibility shim needed.