### PR TITLE
fix: avoid initializing shared storage during wrapper setup

### DIFF
--- a/lib/Listener/FilesystemSetupListener.php
+++ b/lib/Listener/FilesystemSetupListener.php
@@ -62,16 +62,7 @@ class FilesystemSetupListener implements IEventListener {
 		Filesystem::addStorageWrapper(
 			'oc_avir',
 			function (string $mountPoint, IStorage $storage) {
-				if (
-					$storage->instanceOfStorage(AvirWrapper::class)
-					&& $storage->instanceOfStorage(Jail::class) && (
-						$storage->instanceOfStorage(ISharedStorage::class)
-						|| !(
-							$this->groupFolderEncryptionEnabled
-							&& $storage->instanceOfStorage(GroupFolderEncryptionJail::class)
-						)
-					)
-				) {
+				if ($this->shouldSkipWrapping($storage)) {
 					// No reason to wrap jails again.
 					// Make an exception for encrypted group folders.
 					return $storage;
@@ -99,6 +90,22 @@ class FilesystemSetupListener implements IEventListener {
 			},
 			1,
 		);
+	}
+
+	private function shouldSkipWrapping(IStorage $storage): bool {
+		return $storage->instanceOfStorage(Jail::class)
+			&& (
+				// Check shared storage before AvirWrapper to avoid triggering
+				// lazy initialization while inspecting the wrapper chain.
+				$storage->instanceOfStorage(ISharedStorage::class)
+				|| (
+					$storage->instanceOfStorage(AvirWrapper::class)
+					&& !(
+						$this->groupFolderEncryptionEnabled
+						&& $storage->instanceOfStorage(GroupFolderEncryptionJail::class)
+					)
+				)
+			);
 	}
 
 }

--- a/tests/Listener/FilesystemSetupListenerTest.php
+++ b/tests/Listener/FilesystemSetupListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Antivirus\Tests\Listener;
+
+use OC\Files\Storage\Wrapper\Jail;
+use OCA\Files_Antivirus\AvirWrapper;
+use OCA\Files_Antivirus\Listener\FilesystemSetupListener;
+use OCA\GroupFolders\Mount\GroupFolderEncryptionJail;
+use OCP\Files\Storage\ISharedStorage;
+use OCP\Files\Storage\IStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class FilesystemSetupListenerTest extends TestCase {
+	public function testSharedStorageIsCheckedBeforeAvirWrapper(): void {
+		$checkedClasses = [];
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')
+			->willReturnCallback(function (string $class) use (&$checkedClasses): bool {
+				$checkedClasses[] = $class;
+
+				return match ($class) {
+					Jail::class, ISharedStorage::class => true,
+					AvirWrapper::class => self::fail('AvirWrapper must not be checked for shared storage'),
+					default => false,
+				};
+			});
+
+		self::assertTrue($this->shouldSkipWrapping($storage));
+		self::assertSame([
+			Jail::class,
+			ISharedStorage::class,
+		], $checkedClasses);
+	}
+
+	public function testWrappedJailIsSkipped(): void {
+		$storage = $this->getStorageMock([
+			Jail::class => true,
+			ISharedStorage::class => false,
+			AvirWrapper::class => true,
+		]);
+
+		self::assertTrue($this->shouldSkipWrapping($storage));
+	}
+
+	public function testUnwrappedJailIsNotSkipped(): void {
+		$storage = $this->getStorageMock([
+			Jail::class => true,
+			ISharedStorage::class => false,
+			AvirWrapper::class => false,
+		]);
+
+		self::assertFalse($this->shouldSkipWrapping($storage));
+	}
+
+	public function testEncryptedGroupFolderIsNotSkipped(): void {
+		$storage = $this->getStorageMock([
+			Jail::class => true,
+			ISharedStorage::class => false,
+			AvirWrapper::class => true,
+			GroupFolderEncryptionJail::class => true,
+		]);
+
+		self::assertFalse($this->shouldSkipWrapping($storage, true));
+	}
+
+	/**
+	 * @param array<class-string, bool> $storageTypes
+	 */
+	private function getStorageMock(array $storageTypes): IStorage&MockObject {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')
+			->willReturnCallback(fn (string $class): bool => $storageTypes[$class] ?? false);
+
+		return $storage;
+	}
+
+	private function shouldSkipWrapping(IStorage $storage, bool $groupFolderEncryptionEnabled = false): bool {
+		$reflection = new \ReflectionClass(FilesystemSetupListener::class);
+		$listener = $reflection->newInstanceWithoutConstructor();
+		$reflection->getProperty('groupFolderEncryptionEnabled')->setValue($listener, $groupFolderEncryptionEnabled);
+
+		return $reflection->getMethod('shouldSkipWrapping')->invoke($listener, $storage);
+	}
+}


### PR DESCRIPTION
## Summary

- avoid traversing the wrapper chain of lazy shared storages while setting up the antivirus wrapper
- preserve the existing behavior for wrapped jails and encrypted Group Folders
- add regression tests for shared storage and jail wrapper combinations

## Problem

`FilesystemSetupListener` currently checks `AvirWrapper` before determining whether a jail wraps an `ISharedStorage`. The recursive `instanceOfStorage(AvirWrapper::class)` lookup can reach `SharedStorage::getWrapperStorage()` and force its lazy initialization.

This becomes especially expensive while the Files root is loaded because its WebDAV properties aggregate metadata from every mounted sub-storage.

The change checks `Jail` and `ISharedStorage` first. Shared-storage jails can then be skipped without resolving their wrapped storage, while the existing antivirus and encrypted Group Folder behavior remains intact.

Addresses #698.

## Validation

- targeted PHPUnit: 4 tests, 5 assertions
- PHP lint: passed
- PHP CS Fixer dry run: passed
- full suite: 53 tests; one unrelated `ScannerFactoryTest` failure reproduced unchanged on `upstream/master` in the same Nextcloud 32 harness
